### PR TITLE
Fix artifact creation to include all SonarCloud coverage reports

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,6 +84,7 @@ jobs:
           name: sonar-reports
           path: |
             coverage/lcov.info
+            sonar-report.xml
 
   sonarcloud:
     name: SonarCloud Scan
@@ -100,6 +101,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: sonar-reports
+
+      - run: ls -la
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@v5.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -14671,6 +14671,19 @@
         }
       }
     },
+    "node_modules/vitest-sonar-reporter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vitest-sonar-reporter/-/vitest-sonar-reporter-2.0.0.tgz",
+      "integrity": "sha512-LorC3NnmrBrryx4+l3BEsNQjD0Y7wfmrD1y/+tHDuZUuVj7w8nOxRXCBSppDfmgfpToOhwchh0JcL4IGMKUKDA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vitest": ">=1"
+      }
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -15307,7 +15320,8 @@
         "react": "^19.0.0",
         "typescript": "^5.8.2",
         "vite-tsconfig-paths": "^5.1.4",
-        "vitest": "^3.0.9"
+        "vitest": "^3.0.9",
+        "vitest-sonar-reporter": "^2.0.0"
       },
       "engines": {
         "node": ">= 22"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -62,7 +62,8 @@
     "react": "^19.0.0",
     "typescript": "^5.8.2",
     "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^3.0.9"
+    "vitest": "^3.0.9",
+    "vitest-sonar-reporter": "^2.0.0"
   },
   "prettier": "@pplancq/prettier-config",
   "lint-staged": {

--- a/packages/react/vitest.config.mts
+++ b/packages/react/vitest.config.mts
@@ -16,8 +16,9 @@ export default defineConfig(({ mode }) => {
       clearMocks: true,
       css: false,
       include: ['tests/**/*.{test,spec}.[jt]s?(x)'],
-      reporters: ['default', 'junit'],
+      reporters: ['default', 'junit', 'vitest-sonar-reporter'],
       outputFile: {
+        'vitest-sonar-reporter': 'sonar-report.xml',
         junit: 'junit-report.xml',
       },
       poolOptions: {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,6 +8,7 @@ sonar.sources = packages/react/src,packages/css/sass
 
 sonar.tests = packages/react/tests
 sonar.tests.inclusions = **/*.(spec|test).[jt]s?(x)
+sonar.testExecutionReportPaths = sonar-report.xml
 
 sonar.javascript.lcov.reportPaths = coverage/lcov.info
 sonar.coverage.exclusions = packages/react/src/**/*.d.[jt]s?(x), packages/react/src/**/*.types.[jt]s?(x), packages/react/src/**/index.[jt]s?(x)

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -6,8 +6,9 @@ export default defineConfig(({ mode }) => {
 
   return {
     test: {
-      reporters: ['default', 'junit'],
+      reporters: ['default', 'junit', 'vitest-sonar-reporter'],
       outputFile: {
+        'vitest-sonar-reporter': 'sonar-report.xml',
         junit: 'junit-report.xml',
       },
       poolOptions: {


### PR DESCRIPTION
**Type of Pull Request :**  
- [x] Bug fix

**Associated Issue :**  
Closes: [#37](https://github.com/pplancq/shelter-ui/issues/37)

**Context :**  
Previously, the artifact creation for SonarCloud was misconfigured. The `coverage` directory was not preserved, and only the `lcov.info` file was uploaded. This caused issues during the artifact retrieval step for the SonarCloud analysis task. To address this, an updated configuration was implemented to include the required `sonar-report.xml` file alongside `coverage/lcov.info`, ensuring the directory structure is preserved.

**Proposed Changes :**  
- Modified the GitHub Actions workflow to include an additional test report (`sonar-report.xml`) in the artifact.  
- Updated the artifact path configuration to preserve the `coverage` folder when uploading to SonarCloud.  
- Tested the workflow to confirm that both files are correctly included and accessible.

**Checklist :**  
- [x] I have verified that my changes work as expected.  
- [x] I have updated the documentation if necessary.  
- [x] I have thought to rebase my branch.  
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation).

**Additional Information :**  
This fix ensures the full compatibility of test coverage reports with SonarCloud, reducing potential interruptions in CI/CD processes. Future improvements may include additional validation steps for artifact integrity.