### PR TITLE
Centralize Primitive Colors as SCSS Variables for ShelterUI Design System

### DIFF
--- a/packages/css/sass/variables/_color.scss
+++ b/packages/css/sass/variables/_color.scss
@@ -1,0 +1,241 @@
+/* blue */
+$color-blue-50: hsl(226deg 63% 95%); /* #E9EDFA */
+$color-blue-100: hsl(225deg 64% 89%); /* #D2DBF5 */
+$color-blue-150: hsl(225deg 65% 84%); /* #BCC9F1 */
+$color-blue-200: hsl(225deg 65% 79%); /* #A6B7EC */
+$color-blue-250: hsl(225deg 64% 74%); /* #90A6E7 */
+$color-blue-300: hsl(225deg 64% 68%); /* #7994E2 */
+$color-blue-350: hsl(225deg 64% 63%); /* #6382DD */
+$color-blue-400: hsl(225deg 65% 58%); /* #4D70D9 */
+$color-blue-450: hsl(225deg 65% 52%); /* #365ED4 */
+$color-blue-500: hsl(225deg 73% 47%); /* #204CCF */
+$color-blue-550: hsl(225deg 73% 42%); /* #1D44BA */
+$color-blue-600: hsl(225deg 73% 38%); /* #1A3DA6 */
+$color-blue-650: hsl(225deg 74% 33%); /* #163591 */
+$color-blue-700: hsl(225deg 73% 28%); /* #132E7C */
+$color-blue-750: hsl(225deg 73% 24%); /* #102668 */
+$color-blue-800: hsl(225deg 73% 19%); /* #0D1E53 */
+$color-blue-850: hsl(225deg 72% 14%); /* #0A173E */
+$color-blue-900: hsl(225deg 74% 9%); /* #060F29 */
+$color-blue-950: hsl(223deg 75% 5%); /* #030815 */
+$color-blue-A10: hsl(225deg 73% 47% / 10%); /* #204CCF1A */
+$color-blue-A20: hsl(225deg 73% 47% / 20%); /* #204CCF33 */
+$color-blue-A30: hsl(225deg 73% 47% / 30%); /* #204CCF4D */
+$color-blue-A40: hsl(225deg 73% 47% / 40%); /* #204CCF66 */
+$color-blue-A50: hsl(225deg 73% 47% / 50%); /* #204CCF80 */
+$color-blue-A60: hsl(225deg 73% 47% / 60%); /* #204CCF99 */
+$color-blue-A70: hsl(225deg 73% 47% / 70%); /* #204CCFB3 */
+$color-blue-A80: hsl(225deg 73% 47% / 80%); /* #204CCFCC */
+$color-blue-A90: hsl(225deg 73% 47% / 90%); /* #204CCFE6 */
+
+/* purple */
+$color-purple-50: hsl(263deg 48% 95%); /* #F0EBF8 */
+$color-purple-100: hsl(262deg 47% 90%); /* #E1D8F1 */
+$color-purple-150: hsl(261deg 46% 84%); /* #D1C4E9 */
+$color-purple-200: hsl(262deg 46% 79%); /* #C2B0E2 */
+$color-purple-250: hsl(261deg 46% 74%); /* #B39DDB */
+$color-purple-300: hsl(262deg 47% 68%); /* #A489D4 */
+$color-purple-350: hsl(262deg 47% 63%); /* #9575CD */
+$color-purple-400: hsl(262deg 46% 58%); /* #8561C5 */
+$color-purple-450: hsl(261deg 46% 53%); /* #764EBE */
+$color-purple-500: hsl(262deg 52% 47%); /* #673AB7 */
+$color-purple-550: hsl(262deg 52% 43%); /* #5D34A5 */
+$color-purple-600: hsl(262deg 52% 38%); /* #522E92 */
+$color-purple-650: hsl(261deg 51% 33%); /* #482980 */
+$color-purple-700: hsl(262deg 52% 28%); /* #3E236E */
+$color-purple-750: hsl(262deg 52% 24%); /* #341D5C */
+$color-purple-800: hsl(262deg 52% 19%); /* #291749 */
+$color-purple-850: hsl(262deg 53% 14%); /* #1F1137 */
+$color-purple-900: hsl(262deg 51% 10%); /* #150C25 */
+$color-purple-950: hsl(260deg 50% 5%); /* #0A0612 */
+$color-purple-A10: hsl(262deg 52% 47% / 10%); /* #673AB71A */
+$color-purple-A20: hsl(262deg 52% 47% / 20%); /* #673AB733 */
+$color-purple-A30: hsl(262deg 52% 47% / 30%); /* #673AB74D */
+$color-purple-A40: hsl(262deg 52% 47% / 40%); /* #673AB766 */
+$color-purple-A50: hsl(262deg 52% 47% / 50%); /* #673AB780 */
+$color-purple-A60: hsl(262deg 52% 47% / 60%); /* #673AB799 */
+$color-purple-A70: hsl(262deg 52% 47% / 70%); /* #673AB7B3 */
+$color-purple-A80: hsl(262deg 52% 47% / 80%); /* #673AB7CC */
+$color-purple-A90: hsl(262deg 52% 47% / 90%); /* #673AB7E6 */
+
+/* cyan */
+$color-cyan-50: hsl(187deg 59% 94%); /* #E8F7F9 */
+$color-cyan-100: hsl(189deg 59% 89%); /* #D1EEF3 */
+$color-cyan-150: hsl(188deg 59% 83%); /* #BAE6ED */
+$color-cyan-200: hsl(188deg 59% 77%); /* #A3DEE7 */
+$color-cyan-250: hsl(188deg 59% 72%); /* #8CD6E1 */
+$color-cyan-300: hsl(188deg 59% 66%); /* #74CDDB */
+$color-cyan-350: hsl(188deg 59% 60%); /* #5DC5D5 */
+$color-cyan-400: hsl(188deg 59% 54%); /* #46BDCF */
+$color-cyan-450: hsl(188deg 62% 49%); /* #2FB4C9 */
+$color-cyan-500: hsl(188deg 78% 43%); /* #18ACC3 */
+$color-cyan-550: hsl(188deg 78% 39%); /* #169BB0 */
+$color-cyan-600: hsl(188deg 78% 34%); /* #138A9C */
+$color-cyan-650: hsl(189deg 78% 30%); /* #117889 */
+$color-cyan-700: hsl(188deg 79% 26%); /* #0E6775 */
+$color-cyan-750: hsl(188deg 78% 22%); /* #0C5662 */
+$color-cyan-800: hsl(188deg 77% 17%); /* #0A454E */
+$color-cyan-850: hsl(187deg 78% 13%); /* #07343A */
+$color-cyan-900: hsl(189deg 77% 9%); /* #052227 */
+$color-cyan-950: hsl(187deg 81% 4%); /* #021113 */
+$color-cyan-A10: hsl(188deg 78% 43% / 10%); /* #18ACC31A */
+$color-cyan-A20: hsl(188deg 78% 43% / 20%); /* #18ACC333 */
+$color-cyan-A30: hsl(188deg 78% 43% / 30%); /* #18ACC34D */
+$color-cyan-A40: hsl(188deg 78% 43% / 40%); /* #18ACC366 */
+$color-cyan-A50: hsl(188deg 78% 43% / 50%); /* #18ACC380 */
+$color-cyan-A60: hsl(188deg 78% 43% / 60%); /* #18ACC399 */
+$color-cyan-A70: hsl(188deg 78% 43% / 70%); /* #18ACC3B3 */
+$color-cyan-A80: hsl(188deg 78% 43% / 80%); /* #18ACC3CC */
+$color-cyan-A90: hsl(188deg 78% 43% / 90%); /* #18ACC3E6 */
+
+/* green */
+$color-green-50: hsl(133deg 50% 95%); /* #EAF8ED */
+$color-green-100: hsl(133deg 47% 89%); /* #D5F0DB */
+$color-green-150: hsl(133deg 48% 83%); /* #C0E9C9 */
+$color-green-200: hsl(133deg 47% 78%); /* #ABE1B7 */
+$color-green-250: hsl(134deg 48% 72%); /* #96DAA6 */
+$color-green-300: hsl(134deg 49% 66%); /* #80D394 */
+$color-green-350: hsl(134deg 48% 61%); /* #6BCB82 */
+$color-green-400: hsl(134deg 48% 55%); /* #56C470 */
+$color-green-450: hsl(134deg 49% 50%); /* #41BC5E */
+$color-green-500: hsl(134deg 61% 44%); /* #2CB54C */
+$color-green-550: hsl(134deg 61% 40%); /* #28A344 */
+$color-green-600: hsl(134deg 61% 35%); /* #23913D */
+$color-green-650: hsl(134deg 61% 31%); /* #1F7F35 */
+$color-green-700: hsl(134deg 61% 26%); /* #1A6D2E */
+$color-green-750: hsl(134deg 61% 22%); /* #165B26 */
+$color-green-800: hsl(133deg 60% 18%); /* #12481E */
+$color-green-850: hsl(135deg 61% 13%); /* #0D3617 */
+$color-green-900: hsl(133deg 60% 9%); /* #09240F */
+$color-green-950: hsl(137deg 64% 4%); /* #041208 */
+$color-green-A10: hsl(134deg 61% 40% / 10%); /* #28A3441A */
+$color-green-A20: hsl(134deg 61% 40% / 20%); /* #28A34433 */
+$color-green-A30: hsl(134deg 61% 40% / 30%); /* #28A3444D */
+$color-green-A40: hsl(134deg 61% 40% / 40%); /* #28A34466 */
+$color-green-A50: hsl(134deg 61% 40% / 50%); /* #28A34480 */
+$color-green-A60: hsl(134deg 61% 40% / 60%); /* #28A34499 */
+$color-green-A70: hsl(134deg 61% 40% / 70%); /* #28A344B3 */
+$color-green-A80: hsl(134deg 61% 40% / 80%); /* #28A344CC */
+$color-green-A90: hsl(134deg 61% 40% / 90%); /* #28A344E6 */
+
+/* orange */
+$color-orange-50: hsl(46deg 100% 95%); /* #FFF9E6 */
+$color-orange-100: hsl(46deg 100% 90%); /* #FFF3CD */
+$color-orange-150: hsl(45deg 100% 85%); /* #FFECB5 */
+$color-orange-200: hsl(45deg 100% 81%); /* #FFE69C */
+$color-orange-250: hsl(45deg 100% 76%); /* #FFE083 */
+$color-orange-300: hsl(45deg 100% 71%); /* #FFDA6A */
+$color-orange-350: hsl(45deg 100% 66%); /* #FFD451 */
+$color-orange-400: hsl(45deg 100% 61%); /* #FFCD39 */
+$color-orange-450: hsl(45deg 100% 56%); /* #FFC720 */
+$color-orange-500: hsl(45deg 100% 51%); /* #FFC107 */
+$color-orange-550: hsl(45deg 95% 46%); /* #E6AE06 */
+$color-orange-600: hsl(45deg 94% 41%); /* #CC9A06 */
+$color-orange-650: hsl(45deg 95% 36%); /* #B38705 */
+$color-orange-700: hsl(45deg 95% 31%); /* #997404 */
+$color-orange-750: hsl(45deg 94% 26%); /* #806104 */
+$color-orange-800: hsl(45deg 94% 21%); /* #664D03 */
+$color-orange-850: hsl(45deg 95% 15%); /* #4C3A02 */
+$color-orange-900: hsl(46deg 96% 10%); /* #332701 */
+$color-orange-950: hsl(45deg 92% 5%); /* #191301 */
+$color-orange-A10: hsl(45deg 100% 51% / 10%); /* #FFC1071A */
+$color-orange-A20: hsl(45deg 100% 51% / 20%); /* #FFC10733 */
+$color-orange-A30: hsl(45deg 100% 51% / 30%); /* #FFC1074D */
+$color-orange-A40: hsl(45deg 100% 51% / 40%); /* #FFC10766 */
+$color-orange-A50: hsl(45deg 100% 51% / 50%); /* #FFC10780 */
+$color-orange-A60: hsl(45deg 100% 51% / 60%); /* #FFC10799 */
+$color-orange-A70: hsl(45deg 100% 51% / 70%); /* #FFC107B3 */
+$color-orange-A80: hsl(45deg 100% 51% / 80%); /* #FFC107CC */
+$color-orange-A90: hsl(45deg 100% 51% / 90%); /* #FFC107E6 */
+
+/* red */
+$color-red-50: hsl(0deg 52% 94%); /* #F7E6E6 */
+$color-red-100: hsl(0deg 55% 87%); /* #F0CCCC */
+$color-red-150: hsl(0deg 54% 81%); /* #E8B3B3 */
+$color-red-200: hsl(0deg 55% 74%); /* #E19999 */
+$color-red-250: hsl(0deg 54% 68%); /* #D98080 */
+$color-red-300: hsl(0deg 54% 61%); /* #D16666 */
+$color-red-350: hsl(0deg 54% 55%); /* #CA4D4D */
+$color-red-400: hsl(0deg 58% 48%); /* #C23333 */
+$color-red-450: hsl(0deg 76% 42%); /* #BB1A1A */
+$color-red-500: hsl(0deg 100% 35%); /* #B30000 */
+$color-red-550: hsl(0deg 100% 32%); /* #A10000 */
+$color-red-600: hsl(0deg 100% 28%); /* #8F0000 */
+$color-red-650: hsl(0deg 100% 25%); /* #7D0000 */
+$color-red-700: hsl(0deg 100% 21%); /* #6B0000 */
+$color-red-750: hsl(0deg 100% 18%); /* #5A0000 */
+$color-red-800: hsl(0deg 100% 14%); /* #480000 */
+$color-red-850: hsl(0deg 100% 11%); /* #360000 */
+$color-red-900: hsl(0deg 100% 7%); /* #240000 */
+$color-red-950: hsl(0deg 100% 4%); /* #120000 */
+$color-red-A10: hsl(0deg 100% 35% / 10%); /* #B300001A */
+$color-red-A20: hsl(0deg 100% 35% / 20%); /* #B3000033 */
+$color-red-A30: hsl(0deg 100% 35% / 30%); /* #B300004D */
+$color-red-A40: hsl(0deg 100% 35% / 40%); /* #B3000066 */
+$color-red-A50: hsl(0deg 100% 35% / 50%); /* #B3000080 */
+$color-red-A60: hsl(0deg 100% 35% / 60%); /* #B3000099 */
+$color-red-A70: hsl(0deg 100% 35% / 70%); /* #B30000B3 */
+$color-red-A80: hsl(0deg 100% 35% / 80%); /* #B30000CC */
+$color-red-A90: hsl(0deg 100% 35% / 90%); /* #B30000E6 */
+
+/* neutral */
+$color-neutral-00: hsl(0deg 0% 100%); /* #FFFFFF */
+$color-neutral-50: hsl(0deg 0% 95%); /* #F3F3F3 */
+$color-neutral-100: hsl(0deg 0% 91%); /* #E7E7E7 */
+$color-neutral-150: hsl(0deg 0% 86%); /* #DBDBDB */
+$color-neutral-200: hsl(0deg 0% 81%); /* #CFCFCF */
+$color-neutral-250: hsl(0deg 0% 77%); /* #C4C4C4 */
+$color-neutral-300: hsl(0deg 0% 72%); /* #B8B8B8 */
+$color-neutral-350: hsl(0deg 0% 67%); /* #ACACAC */
+$color-neutral-400: hsl(0deg 0% 63%); /* #A0A0A0 */
+$color-neutral-450: hsl(0deg 0% 58%); /* #949494 */
+$color-neutral-500: hsl(0deg 0% 53%); /* #888888 */
+$color-neutral-550: hsl(0deg 0% 48%); /* #7A7A7A */
+$color-neutral-600: hsl(0deg 0% 43%); /* #6D6D6D */
+$color-neutral-650: hsl(0deg 0% 37%); /* #5F5F5F */
+$color-neutral-700: hsl(0deg 0% 32%); /* #525252 */
+$color-neutral-750: hsl(0deg 0% 27%); /* #444444 */
+$color-neutral-800: hsl(0deg 0% 21%); /* #363636 */
+$color-neutral-850: hsl(0deg 0% 16%); /* #292929 */
+$color-neutral-900: hsl(0deg 0% 11%); /* #1B1B1B */
+$color-neutral-950: hsl(0deg 0% 5%); /* #0E0E0E */
+$color-neutral-1000: hsl(0deg 0% 0%); /* #000000 */
+$color-neutral-A10: hsl(0deg 0% 53% / 10%); /* #8888881A */
+$color-neutral-A20: hsl(0deg 0% 53% / 20%); /* #88888833 */
+$color-neutral-A30: hsl(0deg 0% 53% / 30%); /* #8888884D */
+$color-neutral-A40: hsl(0deg 0% 53% / 40%); /* #88888866 */
+$color-neutral-A50: hsl(0deg 0% 53% / 50%); /* #88888880 */
+$color-neutral-A60: hsl(0deg 0% 53% / 60%); /* #88888899 */
+$color-neutral-A70: hsl(0deg 0% 53% / 70%); /* #888888B3 */
+$color-neutral-A80: hsl(0deg 0% 53% / 80%); /* #888888CC */
+$color-neutral-A90: hsl(0deg 0% 53% / 90%); /* #888888E6 */
+
+/* gray */
+$color-gray-50: hsl(220deg 11% 95%); /* #F0F1F3 */
+$color-gray-100: hsl(228deg 9% 89%); /* #E1E2E6 */
+$color-gray-150: hsl(227deg 11% 84%); /* #D2D4DB */
+$color-gray-200: hsl(228deg 9% 79%); /* #C4C6CE */
+$color-gray-250: hsl(226deg 10% 74%); /* #B5B8C2 */
+$color-gray-300: hsl(222deg 10% 68%); /* #A5AAB6 */
+$color-gray-350: hsl(224deg 10% 63%); /* #969BA9 */
+$color-gray-400: hsl(224deg 10% 58%); /* #888E9E */
+$color-gray-450: hsl(225deg 10% 52%); /* #797F91 */
+$color-gray-500: hsl(224deg 10% 47%); /* #6C7283 */
+$color-gray-550: hsl(226deg 10% 42%); /* #616676 */
+$color-gray-600: hsl(225deg 10% 38%); /* #565B6A */
+$color-gray-650: hsl(226deg 10% 33%); /* #4B4F5C */
+$color-gray-700: hsl(224deg 10% 28%); /* #40444F */
+$color-gray-750: hsl(225deg 10% 24%); /* #363942 */
+$color-gray-800: hsl(222deg 10% 19%); /* #2B2E35 */
+$color-gray-850: hsl(225deg 11% 14%); /* #202228 */
+$color-gray-900: hsl(228deg 11% 9%); /* #15161A */
+$color-gray-950: hsl(240deg 8% 5%); /* #0B0B0D */
+$color-gray-A10: hsl(224deg 10% 47% / 10%); /* #6C72831A */
+$color-gray-A20: hsl(224deg 10% 47% / 20%); /* #6C728333 */
+$color-gray-A30: hsl(224deg 10% 47% / 30%); /* #6C72834D */
+$color-gray-A40: hsl(224deg 10% 47% / 40%); /* #6C728366 */
+$color-gray-A50: hsl(224deg 10% 47% / 50%); /* #6C728380 */
+$color-gray-A60: hsl(224deg 10% 47% / 60%); /* #6C728399 */
+$color-gray-A70: hsl(224deg 10% 47% / 70%); /* #6C7283B3 */
+$color-gray-A80: hsl(224deg 10% 47% / 80%); /* #6C7283CC */
+$color-gray-A90: hsl(224deg 10% 47% / 90%); /* #6C7283E6 */

--- a/packages/css/sass/variables/_tokens.scss
+++ b/packages/css/sass/variables/_tokens.scss
@@ -1,1 +1,2 @@
+@use 'color';
 @use 'dimension';


### PR DESCRIPTION
**Type of Pull Request :**  
- [x] New feature

**Associated Issue :**  
Closes: [#14](https://github.com/pplancq/shelter-ui/issues/14)

**Context :**  
This Pull Request centralizes the definition of primitive colors in SCSS variables for the ShelterUI Design System. By using SCSS variables for primitives, we avoid unnecessary CSS variable exposure in the final stylesheet. Primitives are abstract and act as the foundation, ensuring modularity while preventing direct usage in components. This approach optimizes the CSS output, reduces potential redundancy, and maintains design consistency.

**Proposed Changes :**  
- Defined SCSS variables for all primitive color shades, ranging from `50` to `950`.
- Added alpha-level variations (A10–A90) for each color.
- Ensured color primitives follow the `{hue}-{intensity}` naming convention (e.g., `$blue-500`).
- Organized colors into a centralized SCSS file for maintainability.

**Checklist :**  
- [x] I have verified that my changes work as expected.  
- [x] I have updated the documentation if necessary.  
- [x] I have thought to rebase my branch.  
- [x] I have applied the correct label according to the type of PR (new feature).  

**Additional Information :**  
By centralizing primitive color definitions as SCSS variables, the ShelterUI Design System now has a robust, maintainable approach for managing base colors. These primitives serve as a foundational layer, enabling consistent creation of semantic tokens without cluttering the CSS output.
