### PR TITLE
Add reusable Sass mixins for responsive Figma typography styles

### DIFF
--- a/packages/css/sass/mixins/_typography.scss
+++ b/packages/css/sass/mixins/_typography.scss
@@ -1,0 +1,234 @@
+@use 'sass:map';
+@use '../layout/responsive';
+
+$display: (
+  mobile: (
+    1: (
+      font-size: var(--font-size-48),
+      line-height: var(--line-height-48),
+    ),
+    2: (
+      font-size: var(--font-size-36),
+      line-height: var(--line-height-40),
+    ),
+    3: (
+      font-size: var(--font-size-24),
+      line-height: var(--line-height-32),
+    ),
+    4: (
+      font-size: var(--font-size-20),
+      line-height: var(--line-height-28),
+    ),
+    5: (
+      font-size: var(--font-size-18),
+      line-height: var(--line-height-28),
+    ),
+    6: (
+      font-size: var(--font-size-16),
+      line-height: var(--line-height-24),
+    ),
+  ),
+  desktop: (
+    1: (
+      font-size: var(--font-size-80),
+      line-height: var(--line-height-80),
+    ),
+    2: (
+      font-size: var(--font-size-60),
+      line-height: var(--line-height-60),
+    ),
+    3: (
+      font-size: var(--font-size-48),
+      line-height: var(--line-height-48),
+    ),
+    4: (
+      font-size: var(--font-size-36),
+      line-height: var(--line-height-40),
+    ),
+    5: (
+      font-size: var(--font-size-24),
+      line-height: var(--line-height-32),
+    ),
+    6: (
+      font-size: var(--font-size-20),
+      line-height: var(--line-height-28),
+    ),
+  ),
+);
+
+$heading: (
+  mobile: (
+    1: (
+      font-size: var(--font-size-24),
+      line-height: var(--line-height-32),
+    ),
+    2: (
+      font-size: var(--font-size-20),
+      line-height: var(--line-height-28),
+    ),
+    3: (
+      font-size: var(--font-size-18),
+      line-height: var(--line-height-28),
+    ),
+    4: (
+      font-size: var(--font-size-16),
+      line-height: var(--line-height-24),
+    ),
+    5: (
+      font-size: var(--font-size-14),
+      line-height: var(--line-height-20),
+    ),
+    6: (
+      font-size: var(--font-size-12),
+      line-height: var(--line-height-16),
+    ),
+  ),
+  desktop: (
+    1: (
+      font-size: var(--font-size-30),
+      line-height: var(--line-height-36),
+    ),
+    2: (
+      font-size: var(--font-size-24),
+      line-height: var(--line-height-32),
+    ),
+    3: (
+      font-size: var(--font-size-20),
+      line-height: var(--line-height-28),
+    ),
+    4: (
+      font-size: var(--font-size-18),
+      line-height: var(--line-height-28),
+    ),
+    5: (
+      font-size: var(--font-size-16),
+      line-height: var(--line-height-24),
+    ),
+    6: (
+      font-size: var(--font-size-14),
+      line-height: var(--line-height-20),
+    ),
+  ),
+);
+
+$text: (
+  large: (
+    font-size: var(--font-size-18),
+    line-height: var(--line-height-28),
+  ),
+  medium: (
+    font-size: var(--font-size-16),
+    line-height: var(--line-height-24),
+  ),
+  small: (
+    font-size: var(--font-size-14),
+    line-height: var(--line-height-20),
+  ),
+  smaller: (
+    font-size: var(--font-size-12),
+    line-height: var(--line-height-16),
+  ),
+  smallest: (
+    font-size: var(--font-size-10),
+    line-height: var(--line-height-13),
+  ),
+);
+
+$label: (
+  large: (
+    font-size: var(--font-size-18),
+    line-height: var(--line-height-28),
+  ),
+  medium: (
+    font-size: var(--font-size-16),
+    line-height: var(--line-height-24),
+  ),
+  small: (
+    font-size: var(--font-size-14),
+    line-height: var(--line-height-20),
+  ),
+);
+
+$code: (
+  large: (
+    font-size: var(--font-size-18),
+    line-height: var(--line-height-28),
+  ),
+  medium: (
+    font-size: var(--font-size-16),
+    line-height: var(--line-height-24),
+  ),
+  small: (
+    font-size: var(--font-size-14),
+    line-height: var(--line-height-20),
+  ),
+);
+
+@function _get-typography($map, $size, $property) {
+  @if not(map.has-key($map, $size)) {
+    @error "Invalid size: #{$size}.";
+  }
+  @return map.get(map.get($map, $size), $property);
+}
+
+@mixin _typography($map, $size, $font-family, $font-weight, $letter-spacing) {
+  font-family: $font-family;
+  font-size: _get-typography($map, $size, font-size);
+  font-weight: $font-weight;
+  letter-spacing: $letter-spacing;
+  line-height: _get-typography($map, $size, line-height);
+}
+
+@mixin display($size) {
+  @include _typography(
+    map.get($display, mobile),
+    $size,
+    var(--font-family-display),
+    if($size >= 1 and $size <= 3, var(--font-weight-bold), var(--font-weight-semi-bold)),
+    var(--letter-spacing-default)
+  );
+
+  @include responsive.media-exceeds-width(tablet) {
+    font-size: _get-typography(map.get($display, desktop), $size, font-size);
+    line-height: _get-typography(map.get($display, desktop), $size, line-height);
+  }
+}
+
+@mixin heading($size) {
+  @include _typography(
+    map.get($heading, mobile),
+    $size,
+    var(--font-family-heading),
+    if($size >= 1 and $size <= 3, var(--font-weight-bold), var(--font-weight-semi-bold)),
+    var(--letter-spacing-default)
+  );
+
+  @include responsive.media-exceeds-width(tablet) {
+    font-size: _get-typography(map.get($heading, desktop), $size, font-size);
+    line-height: _get-typography(map.get($heading, desktop), $size, line-height);
+  }
+}
+
+@mixin text($size, $bold: false) {
+  @include _typography(
+    $text,
+    $size,
+    var(--font-family-content),
+    if($bold, var(--font-weight-bold), var(--font-weight-regular)),
+    var(--letter-spacing-default)
+  );
+}
+
+@mixin label($size) {
+  @include _typography(
+    $label,
+    $size,
+    var(--font-family-label),
+    var(--font-weight-semi-bold),
+    var(--letter-spacing-low)
+  );
+}
+
+@mixin code($size) {
+  @include _typography($code, $size, var(--font-family-code), var(--font-weight-medium), var(--letter-spacing-default));
+}

--- a/packages/css/sass/shelter-ui.token.scss
+++ b/packages/css/sass/shelter-ui.token.scss
@@ -1,2 +1,8 @@
 @use 'variables/tokens';
 @use 'themes/theme';
+
+@use 'mixins/typography';
+
+.foo {
+  @include typography.heading(1);
+}


### PR DESCRIPTION
**Type of Pull Request :**

- [x] New feature  

**Associated Issue :**  
Fix [Issue #20](https://github.com/pplancq/shelter-ui/issues/20)

**Context :**  
Applying raw CSS variables repeatedly across files can lead to duplication and errors. To address this, we needed a more streamlined approach to manage typography styles across the project.

**Proposed Changes :**  
- Developed reusable and flexible Sass mixins for Figma typography styles.  
- Introduced specific mixins for `display`, `heading`, `text`, `label`, and `code` components.  
- Integrated responsive support for mobile and desktop typography variants.

**Checklist :**  
- [x] I have verified that my changes work as expected.  
- [x] I have updated the documentation if necessary.  
- [x] I have thought to rebase my branch.  
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation).

**Additional Information :**  
The new mixins enhance consistency and flexibility by supporting various typography variants like `display`, `headings`, `text`, and `labels`. This approach also simplifies component styling and reduces the risk of errors from repetitive CSS variables.