### PR TITLE
Fix: Implement React Typography component with utility CSS classes and tests

### DIFF
--- a/packages/css/.gitignore
+++ b/packages/css/.gitignore
@@ -7,6 +7,7 @@
 node_modules
 dist/
 css/
+font/
 
 # IDE
 .vscode/*

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -18,6 +18,7 @@
   "files": [
     "sass",
     "css",
+    "font",
     "README.md",
     "LICENSE",
     "CHANGELOG.md"

--- a/packages/css/rslib.config.mjs
+++ b/packages/css/rslib.config.mjs
@@ -18,7 +18,7 @@ export default defineConfig({
     target: 'web',
     distPath: {
       root: 'css',
-      font: 'font',
+      font: '../font',
     },
   },
 });

--- a/packages/css/sass/components/typography.scss
+++ b/packages/css/sass/components/typography.scss
@@ -1,0 +1,38 @@
+@forward '@fontsource/raleway/600.css'; /* semi-bold */
+@forward '@fontsource/raleway/700.css'; /* bold */
+@forward '@fontsource/nunito/400.css'; /* regular */
+@forward '@fontsource/nunito/700.css'; /* bold */
+@forward '@fontsource/oswald/600.css'; /* semi-bold */
+@forward '@fontsource/jetbrains-mono/500.css'; /* medium */
+@forward '../variables/typography';
+
+@use '../mixins/typography';
+
+.typography {
+  @each $size in 1, 2, 3, 4, 5, 6 {
+    &.d#{$size} {
+      @include typography.display($size);
+    }
+    &.h#{$size} {
+      @include typography.heading($size);
+    }
+  }
+
+  @each $size in smallest, smaller, small, medium, large {
+    &.text-#{$size} {
+      @include typography.text($size);
+    }
+    &.text-bold-#{$size} {
+      @include typography.text($size, true);
+    }
+  }
+
+  @each $size in small, medium, large {
+    &.label-#{$size} {
+      @include typography.label($size);
+    }
+    &.code-#{$size} {
+      @include typography.code($size);
+    }
+  }
+}

--- a/packages/css/sass/shelter-ui.scss
+++ b/packages/css/sass/shelter-ui.scss
@@ -9,3 +9,5 @@
 @use 'themes/theme';
 
 @use 'layout/grid';
+
+@use 'components/typography';

--- a/packages/react/src/Typography/Typography.tsx
+++ b/packages/react/src/Typography/Typography.tsx
@@ -1,0 +1,77 @@
+import { clsx } from '@/utils/clsx';
+import type { ExtendableComponent } from '@/utils/types';
+import { type ElementType, type PropsWithChildren, useMemo } from 'react';
+
+type SizeTitle = 1 | 2 | 3 | 4 | 5 | 6;
+type SizeText = 'small' | 'medium' | 'large';
+type TypographyPropsBase<C extends ElementType> = ExtendableComponent<C>;
+type TypographyPropsTitle<C extends ElementType> = TypographyPropsBase<C> & {
+  variant: 'display' | 'heading';
+  size?: SizeTitle;
+  bold?: false;
+};
+type TypographyPropsText<C extends ElementType> = TypographyPropsBase<C> & {
+  variant?: 'text';
+  size?: 'smallest' | 'smaller' | SizeText;
+  bold?: true;
+};
+type TypographyPropsLabel<C extends ElementType> = TypographyPropsBase<C> & {
+  variant: 'label';
+  size?: SizeText;
+  bold?: false;
+};
+type TypographyPropsCode<C extends ElementType> = TypographyPropsBase<C> & {
+  variant: 'code';
+  size?: SizeText;
+  bold?: false;
+};
+
+export type TypographyProps<C extends ElementType> =
+  | TypographyPropsTitle<C>
+  | TypographyPropsText<C>
+  | TypographyPropsLabel<C>
+  | TypographyPropsCode<C>;
+
+export const Typography = <C extends ElementType = 'p'>(props: PropsWithChildren<TypographyProps<C>>) => {
+  const {
+    variant = 'text',
+    size = 'medium',
+    component,
+    className,
+    bold,
+    ...typographyProps
+  } = props as TypographyPropsBase<C>;
+
+  const Component = useMemo(() => {
+    const defaultComponent = {
+      display: 'span',
+      heading: `h${size}` as ElementType,
+      text: 'p',
+      label: 'span',
+      code: 'code',
+    } as Record<string, ElementType>;
+
+    return component || defaultComponent[variant];
+  }, [component, variant, size]);
+
+  const typographyClassName = clsx(
+    'typography',
+    variant === 'display' && `d${size}`,
+    variant === 'heading' && `h${size}`,
+    variant === 'text' && `text${bold ? '-bold' : ''}-${size}`,
+    variant === 'label' && `label-${size}`,
+    variant === 'code' && `code-${size}`,
+    className,
+  );
+
+  return (
+    <Component
+      className={typographyClassName}
+      {...typographyProps}
+      role={variant === 'display' ? 'heading' : typographyProps.role}
+      aria-level={['display', 'heading'].includes(variant) ? size : typographyProps['aria-level']}
+    />
+  );
+};
+
+Typography.displayName = 'Typography';

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,1 +1,2 @@
 export { Grid, type GridProps } from './Grid/Grid';
+export { Typography, type TypographyProps } from './Typography/Typography';

--- a/packages/react/tests/Typography/Typography.test.tsx
+++ b/packages/react/tests/Typography/Typography.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Typography } from '../../src/Typography/Typography';
+
+describe('Typography component', () => {
+  it('should render the correct tag for the "heading" variant', () => {
+    render(
+      <Typography variant="heading" size={2}>
+        Demo Title for testing
+      </Typography>,
+    );
+    const element = screen.getByText('Demo Title for testing');
+    expect(element.tagName).toBe('H2');
+    expect(element).toHaveClass('typography', 'h2');
+  });
+
+  it('should apply the correct classes for the "text" variant with bold', () => {
+    render(
+      <Typography variant="text" size="large" bold>
+        Demo text for testing
+      </Typography>,
+    );
+    const element = screen.getByText('Demo text for testing');
+    expect(element.tagName).toBe('P');
+    expect(element).toHaveClass('typography', 'text-bold-large');
+  });
+
+  it('should add ARIA attributes for the "display" variant', () => {
+    render(
+      <Typography variant="display" size={1}>
+        Demo display title for testing
+      </Typography>,
+    );
+    const element = screen.getByText('Demo display title for testing');
+    expect(element).toHaveAttribute('role', 'heading');
+    expect(element).toHaveAttribute('aria-level', '1');
+  });
+
+  it('should allow overriding HTML props', () => {
+    render(
+      <Typography variant="text" size="medium" aria-label="Custom Label">
+        Demo text for testing
+      </Typography>,
+    );
+    const element = screen.getByText('Demo text for testing');
+    expect(element).toHaveAttribute('aria-label', 'Custom Label');
+  });
+
+  it('should render with a custom component (e.g., Link) when the "component" prop is provided', () => {
+    render(
+      <Typography variant="text" size="medium" component="a" href="/test-link">
+        Demo link text
+      </Typography>,
+    );
+    const element = screen.getByText('Demo link text');
+    expect(element.tagName).toBe('A');
+    expect(element).toHaveAttribute('href', '/test-link');
+    expect(element).toHaveClass('typography', 'text-medium');
+  });
+});


### PR DESCRIPTION
**Type of Pull Request :**

- [x] New feature

**Associated Issue :**  
Fix [Issue #21](https://github.com/pplancq/shelter-ui/issues/21)

**Context :**  
There’s no centralized component to apply typography styles based on variants. This PR introduces a robust solution by creating a React Typography component and utility CSS classes.

**Proposed Changes :**
- Developed utility CSS classes for typography styles, leveraging Sass mixins for flexible and reusable designs.
- Implemented a React `Typography` component that manages typography variants (`display`, `heading`, `text`, `label`, and `code`) through a single `variant` prop.
- Enhanced the `Typography` component with size-based classes (`d1`, `h1`, `text-medium`, etc.) for simplified and dynamic usage in projects.
- Included logical defaults, such as `role` and `aria-level`, for improved accessibility.
- Added corresponding unit tests to ensure the reliability and functionality of the `Typography` component.

**Checklist :**
- [x] I have verified that my changes work as expected.
- [x] I have added tests for the new functionality.
- [x] I have updated the documentation if necessary.
- [x] I have thought to rebase my branch.
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation).

**Additional Information :**  
The inclusion of this component simplifies typography styling, promotes consistency, and aligns perfectly with design tokens, reducing redundancy across components.
