### PR TITLE
Fix: Add interactive Storybook typography documentation and component experiments

### DIFF
--- a/apps/storybook/stories/Components/Typography.mdx
+++ b/apps/storybook/stories/Components/Typography.mdx
@@ -1,0 +1,208 @@
+import { Canvas, Controls, Meta, Typeset } from '@storybook/blocks';
+import React from 'react';
+import * as TypographyStories from './Typography.stories';
+
+<Meta of={TypographyStories} name="Typography" />
+
+# ShelterUI Design System Typography
+
+Typography is a key element of ShelterUI's visual identity. It defines the character and tone of the user interface.
+This typography guide describes the styles used for display texts, headings, and general texts, as well as their variants for mobile and desktop.
+
+## Usage of the Typography Component
+
+```tsx
+import { Typography } from '@pplancq/shelter-ui-react';
+
+const MyComponent = () => {
+  return (
+    <Typography variant="heading" size={2}>
+      Example Heading
+    </Typography>
+  );
+};
+```
+
+## Typography Props
+
+<table id="typography-props">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Type</th>
+      <th>Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>
+        <code>variant</code>
+      </th>
+      <td>
+        <code>'display' | 'heading' | 'text' | 'label' | 'code'</code>
+      </td>
+      <td>
+        <code>'text'</code>
+      </td>
+      <td>Defines the typography style.</td>
+    </tr>
+    <tr>
+      <th>
+        <code>size</code>
+      </th>
+      <td>
+        <pre>
+          <code style={{ fontSize: 14 }}>
+            {`for 'display' or 'heading':
+1 | 2 | 3 | 4 | 5 | 6
+
+for 'text':
+'smallest' | 'smaller' |
+'small' | 'medium' | 'large'
+
+for 'label' or 'code':
+'small' | 'medium' | 'large'
+`}
+          </code>
+        </pre>
+      </td>
+      <td>
+        <code>'medium'</code>
+      </td>
+      <td>Specifies the size of the typography.</td>
+    </tr>
+    <tr>
+      <th>
+        <code>bold</code>
+      </th>
+      <td>
+        <code>boolean</code>
+      </td>
+      <td>
+        <code>false</code>
+      </td>
+      <td>Applies bold styling (only for the 'text' variant).</td>
+    </tr>
+    <tr>
+      <th>
+        <code>component</code>
+      </th>
+      <td>
+        <code>ElementType</code>
+      </td>
+      <td>
+        <pre>
+          <code style={{ fontSize: 14 }}>
+            {`'display': 'span'
+'heading': 'h1' to 'h6'
+'text': 'p'
+'label': 'span'
+'code': 'code'`}
+</code>
+</pre>
+</td>
+<td>Overrides the default HTML element used.</td>
+</tr>
+<tr>
+<th>
+<code>className</code>
+</th>
+<td>
+<code>string</code>
+</td>
+<td>-</td>
+<td>Additional CSS classes to apply.</td>
+</tr>
+
+  </tbody>
+</table>
+
+## Demo
+
+This example demonstrates the use of the `Typography` component with different variants and sizes.
+
+<Canvas of={TypographyStories.ExampleLayout} sourceState="shown" />
+
+<Controls of={TypographyStories.ExampleLayout} />
+
+## Using the `component` Prop
+
+The `component` prop allows you to override the default HTML element used by the `Typography` component.
+This is particularly useful when integrating `Typography` into other components.
+
+For example, here is how you can use the `Typography` component with the `label` variant inside a custom `Button` component:
+
+```tsx
+import { Typography } from '@pplancq/shelter-ui-react';
+
+const Button = ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => {
+  return (
+    <Typography component="button" variant="label" size="medium" {...props} className="custom-button">
+      {children}
+    </Typography>
+  );
+};
+
+// Usage
+<Button onClick={() => alert('Clicked!')}>Click Me</Button>;
+```
+
+In this example:
+
+- The `Typography` component is used with the `label` variant.
+- The `component` prop is set to `button` to ensure proper semantics inside the `button` element.
+
+## Typography Variants
+
+### Display
+
+**Font:** Raleway\
+**Weights:** 700 (bold), 600 (semi-bold)
+
+#### Desktop
+
+<Typeset fontSizes={[80, 60, 48]} fontWeight={700} sampleText="Display Variant Example" fontFamily="Raleway" />
+<Typeset fontSizes={[36, 24, 20]} fontWeight={600} sampleText="Display Variant Example" fontFamily="Raleway" />
+
+#### Mobile
+
+<Typeset fontSizes={[48, 36, 24]} fontWeight={700} sampleText="Display Variant Example" fontFamily="Raleway" />
+<Typeset fontSizes={[20, 18, 16]} fontWeight={600} sampleText="Display Variant Example" fontFamily="Raleway" />
+
+### Heading
+
+**Font:** Raleway\
+**Weights:** 700 (bold), 600 (semi-bold)
+
+#### Desktop
+
+<Typeset fontSizes={[30, 24, 20]} fontWeight={700} sampleText="Heading Variant Example" fontFamily="Raleway" />
+<Typeset fontSizes={[18, 16, 14]} fontWeight={600} sampleText="Heading Variant Example" fontFamily="Raleway" />
+
+#### Mobile
+
+<Typeset fontSizes={[24, 20, 18]} fontWeight={700} sampleText="Heading Variant Example" fontFamily="Raleway" />
+<Typeset fontSizes={[16, 14, 12]} fontWeight={600} sampleText="Heading Variant Example" fontFamily="Raleway" />
+
+### Text
+
+**Font:** Nunito  
+**Weights:** 400 (regular), 700 (bold)
+
+<Typeset fontSizes={[18, 16, 14, 12, 10]} fontWeight={400} sampleText="Text Variant Example" fontFamily="Nunito" />
+<Typeset fontSizes={[18, 16, 14, 12, 10]} fontWeight={500} sampleText="Text Bold Variant Example" fontFamily="Nunito" />
+
+### Label
+
+**Font:** Nunito  
+**Weights:** 400 (regular)
+
+<Typeset fontSizes={[18, 16, 14]} fontWeight={400} sampleText="Label Variant Example" fontFamily="Nunito" />
+
+### Code
+
+**Font:** JetBrains Mono  
+**Weights:** 500 (medium)
+
+<Typeset fontSizes={[18, 16, 14]} fontWeight={500} sampleText="Code Variant Example" fontFamily="JetBrains Mono" />

--- a/apps/storybook/stories/Components/Typography.stories.tsx
+++ b/apps/storybook/stories/Components/Typography.stories.tsx
@@ -1,0 +1,103 @@
+import { Typography, type TypographyProps } from '@pplancq/shelter-ui-react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import '@pplancq/shelter-ui-css/sass/components/typography.scss';
+
+const meta = {
+  title: 'Components/Typography',
+  component: Typography,
+
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['!autodocs', 'dev'],
+  args: {
+    variant: 'text',
+    sizeHeading: 1,
+    sizeDisplay: 1,
+    sizeText: 'medium',
+    sizeLabel: 'medium',
+    sizeCode: 'medium',
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['display', 'heading', 'text', 'label', 'code'],
+    },
+    sizeHeading: {
+      name: 'size',
+      if: {
+        arg: 'variant',
+        eq: 'heading',
+      },
+      control: 'select',
+      options: [1, 2, 3, 4, 5, 6],
+    },
+    sizeDisplay: {
+      name: 'size',
+      if: {
+        arg: 'variant',
+        eq: 'display',
+      },
+      control: 'select',
+      options: [1, 2, 3, 4, 5, 6],
+    },
+    sizeText: {
+      name: 'size',
+      if: {
+        arg: 'variant',
+        eq: 'text',
+      },
+      control: 'select',
+      options: ['smallest', 'smaller', 'small', 'medium', 'large'],
+    },
+    sizeLabel: {
+      name: 'size',
+      if: {
+        arg: 'variant',
+        eq: 'label',
+      },
+      control: 'select',
+      options: ['small', 'medium', 'large'],
+    },
+    sizeCode: {
+      name: 'size',
+      if: {
+        arg: 'variant',
+        eq: 'code',
+      },
+      control: 'select',
+      options: ['small', 'medium', 'large'],
+    },
+  },
+} satisfies Meta<
+  TypographyProps<'p'> & {
+    sizeHeading: 1 | 2 | 3 | 4 | 5 | 6;
+    sizeDisplay: 1 | 2 | 3 | 4 | 5 | 6;
+    sizeText: 'smallest' | 'smaller' | 'small' | 'medium' | 'large';
+    sizeLabel: 'small' | 'medium' | 'large';
+    sizeCode: 'small' | 'medium' | 'large';
+  }
+>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const ExampleLayout: Story = {
+  name: 'Typography',
+  render: ({ sizeHeading, sizeDisplay, sizeText, sizeLabel, sizeCode, ...args }) => {
+    const size = {
+      display: sizeDisplay,
+      heading: sizeHeading,
+      text: sizeText,
+      label: sizeLabel,
+      code: sizeCode,
+    };
+    return (
+      <Typography {...args} size={size[(args.variant as keyof typeof size) ?? 'text']}>
+        Lorem ipsum dolor sit amet
+      </Typography>
+    );
+  },
+};


### PR DESCRIPTION
**Type of Pull Request :**  
- [x] New feature  

**Associated Issue :**  
Fix [Issue #22](https://github.com/pplancq/shelter-ui/issues/22)

**Context :**  
There’s no visual demonstration or documentation for the typography system in Storybook. This PR introduces interactive stories and documentation to enhance the understanding and usage of typography in ShelterUI.

**Proposed Changes :**  
- Added interactive stories to Storybook to showcase each typography variant (`d1`, `h1`, `large`, etc.).  
- Implemented a Storybook MDX documentation page explaining the usage of the `Typography` component.  
- Demonstrated practical applications of typography using `Canvas` and `Controls` for dynamic exploration.  
- Provided examples detailing the integration of typography components, including overrides via the `component` prop.

**Checklist :**  
- [x] I have verified that my changes work as expected.  
- [x] I have added documentation in Storybook.  
- [x] I have thought to rebase my branch.  
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation).

**Additional Information :**  
This addition ensures developers can dynamically explore typography styles, interact with different variants, and understand best practices directly in Storybook.