### PR TITLE
Add missing heading typography token and correct SCSS spacing forwarding in Button component

### DIFF
--- a/packages/css/sass/components/button.scss
+++ b/packages/css/sass/components/button.scss
@@ -1,5 +1,7 @@
 @forward '@fontsource/oswald/600.css'; /* semi-bold */
 @forward '../variables/typography';
+@forward '../variables/dimension';
+@forward '../variables/border';
 @forward '../themes/light';
 @forward '../themes/dark';
 

--- a/packages/css/sass/shelter-ui.token.scss
+++ b/packages/css/sass/shelter-ui.token.scss
@@ -1,8 +1,2 @@
 @use 'variables/tokens';
 @use 'themes/theme';
-
-@use 'mixins/typography';
-
-.foo {
-  @include typography.heading(1);
-}

--- a/packages/css/sass/variables/_typography.scss
+++ b/packages/css/sass/variables/_typography.scss
@@ -3,6 +3,7 @@
 :root {
   // Font families
   --font-family-display: 'Raleway', sans-serif;
+  --font-family-heading: 'Raleway', sans-serif;
   --font-family-content: 'Nunito', sans-serif;
   --font-family-label: 'Oswald', sans-serif;
   --font-family-code: 'JetBrains Mono', monospace;


### PR DESCRIPTION
**Type of Pull Request :**
- [x] Bug fix

**Associated Issues :**  
Fix [Issue #136](https://github.com/pplancq/shelter-ui/issues/136)  
Fix [Issue #137](https://github.com/pplancq/shelter-ui/issues/137)

**Context :**  
This PR addresses typography and spacing inconsistencies in ShelterUI by ensuring a standardized heading font and correctly forwarding spacing tokens in the Button SCSS.

**Proposed Changes :**
- Added the missing `--font-family-heading` token in the typography variables to ensure consistent styling for headings.
- Updated the Button SCSS to correctly forward spacing-related tokens, improving flexibility in global styling.

**Checklist :**
- [x] I have verified that my changes work as expected.
- [x] I have applied the correct label according to the type of PR (bug fix/documentation).
- [x] I have thought to rebase my branch.

**Additional Information :**  
These fixes enhance ShelterUI's design consistency, improving maintainability and ensuring proper typography usage across components.