### PR TITLE
Add and document typography color management

### DIFF
--- a/apps/storybook/stories/Fondations/Typography.mdx
+++ b/apps/storybook/stories/Fondations/Typography.mdx
@@ -48,6 +48,18 @@ const MyComponent = () => {
     </tr>
     <tr>
       <th>
+        <code>color</code>
+      </th>
+      <td>
+        <code>'primary' | 'secondary' | 'hint' | 'disabled'</code>
+      </td>
+      <td>
+        <code>'primary'</code>
+      </td>
+      <td>Specifies the text color.</td>
+    </tr>
+    <tr>
+      <th>
         <code>size</code>
       </th>
       <td>

--- a/apps/storybook/stories/Fondations/Typography.stories.tsx
+++ b/apps/storybook/stories/Fondations/Typography.stories.tsx
@@ -2,6 +2,7 @@ import { Typography, type TypographyProps } from '@pplancq/shelter-ui-react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import '@pplancq/shelter-ui-css/sass/components/typography.scss';
+import '@pplancq/shelter-ui-css/sass/themes/_theme.scss';
 
 const meta = {
   title: 'Fondations/Typography',
@@ -13,6 +14,7 @@ const meta = {
   tags: ['!autodocs', 'dev'],
   args: {
     variant: 'text',
+    color: 'primary',
     sizeHeading: 1,
     sizeDisplay: 1,
     sizeText: 'medium',
@@ -23,6 +25,10 @@ const meta = {
     variant: {
       control: 'select',
       options: ['display', 'heading', 'text', 'label', 'code'],
+    },
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary', 'hint', 'disabled'],
     },
     sizeHeading: {
       name: 'size',

--- a/packages/css/sass/components/typography.scss
+++ b/packages/css/sass/components/typography.scss
@@ -9,6 +9,8 @@
 @use '../mixins/typography';
 
 .typography {
+  color: var(--typography-color, inherit);
+
   @each $size in 1, 2, 3, 4, 5, 6 {
     &.d#{$size} {
       @include typography.display($size);

--- a/packages/react/src/Typography/Typography.tsx
+++ b/packages/react/src/Typography/Typography.tsx
@@ -4,7 +4,10 @@ import { type ElementType, type PropsWithChildren, useMemo } from 'react';
 
 type SizeTitle = 1 | 2 | 3 | 4 | 5 | 6;
 type SizeText = 'small' | 'medium' | 'large';
-type TypographyPropsBase<C extends ElementType> = ExtendableComponent<C>;
+type Color = 'primary' | 'secondary' | 'hint' | 'disabled';
+type TypographyPropsBase<C extends ElementType> = ExtendableComponent<C> & {
+  color?: Color;
+};
 type TypographyPropsTitle<C extends ElementType> = TypographyPropsBase<C> & {
   variant: 'display' | 'heading';
   size?: SizeTitle;
@@ -36,6 +39,7 @@ export const Typography = <C extends ElementType = 'p'>(props: PropsWithChildren
   const {
     variant = 'text',
     size = 'medium',
+    color = 'primary',
     component,
     className,
     bold,
@@ -68,6 +72,9 @@ export const Typography = <C extends ElementType = 'p'>(props: PropsWithChildren
     <Component
       className={typographyClassName}
       {...typographyProps}
+      style={{
+        '--typography-color': `var(--color-text-${color})`,
+      }}
       role={variant === 'display' ? 'heading' : typographyProps.role}
       aria-level={['display', 'heading'].includes(variant) ? size : typographyProps['aria-level']}
     />

--- a/packages/react/tests/Typography/Typography.test.tsx
+++ b/packages/react/tests/Typography/Typography.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
 import { describe, expect, it } from 'vitest';
 import { Typography } from '../../src/Typography/Typography';
 
@@ -57,4 +58,22 @@ describe('Typography component', () => {
     expect(element).toHaveAttribute('href', '/test-link');
     expect(element).toHaveClass('typography', 'text-medium');
   });
+
+  it.each([
+    ['primary', '--color-text-primary'],
+    ['secondary', '--color-text-secondary'],
+    ['hint', '--color-text-hint'],
+    ['disabled', '--color-text-disabled'],
+  ])(
+    'should apply the correct color class for the "%s" color',
+    (color: ComponentProps<typeof Typography>['color'], expectedVar) => {
+      render(
+        <Typography variant="text" size="medium" color={color}>
+          {`${color.charAt(0).toUpperCase() + color.slice(1)} color text`}
+        </Typography>,
+      );
+      const element = screen.getByText(`${color.charAt(0).toUpperCase() + color.slice(1)} color text`);
+      expect(element).toHaveStyle(`--typography-color: var(${expectedVar})`);
+    },
+  );
 });


### PR DESCRIPTION
**Type of Pull Request :**

- [x] New feature
- [x] Documentation

**Associated Issue :**

[#117](https://github.com/pplancq/shelter-ui/issues/117)

**Context :**

This Pull Request introduces improved color management for the `Typography` component. The goal is to enhance visual consistency and flexibility in text color usage across the UI.

**Proposed Changes :**

- Added new color variables for typography
- Updated the `Typography` component to support color props (`primary`, `secondary`, `hint`, `disabled`)
- Updated documentation in `Typography.mdx` to reflect color usage and variants
- Added and updated unit tests to cover color-related features

**Checklist :**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information :**

No breaking changes. All existing usages of `Typography` remain compatible.