### PR TITLE
Fix: Pass Release Channel as Tag During NPM Publish in CI

### DIFF
--- a/release.config.mjs
+++ b/release.config.mjs
@@ -49,7 +49,7 @@ export default {
       '@semantic-release/exec',
       {
         prepareCmd: 'npm version ${nextRelease.version} --workspace packages',
-        publishCmd: 'npm publish --workspace packages',
+        publishCmd: 'npm publish --workspace packages --tag ${nextRelease.channel}',
       },
     ],
     [


### PR DESCRIPTION
**Type of Pull Request :**

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue :**

N/A

**Context :**

The CI/CD process for publishing packages did not previously set the correct tag during the NPM publish step. This could lead to releases being published without the appropriate channel tag, causing confusion or unintended installs from npm.

**Proposed Changes :**

- Update the `release.config.mjs` file to add the `--tag ${nextRelease.channel}` option to the NPM publish command.
- Ensure that each published package is tagged according to its release channel, improving release management and package distribution.

**Checklist :**

- [x] I have verified that my changes work as expected
- [x ] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information :**

This change ensures that semantic-release can properly handle channel tagging when publishing to npm from CI. No other files were modified.