### PR TITLE
Add hover backdrop for ghost icon-only buttons

### DIFF
--- a/packages/css/sass/components/button.scss
+++ b/packages/css/sass/components/button.scss
@@ -45,6 +45,10 @@
     &:active {
       text-decoration: underline;
     }
+
+    &:hover.button--only-icon {
+      --button-color-background: var(--color-background-overlay);
+    }
   }
 
   &--primary {


### PR DESCRIPTION
**Type of Pull Request :**

- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue :**

Closes #230

**Context :**

Ghost variant icon-only buttons did not provide a visible background change on hover, making it difficult for users to perceive the interactive area and hover state. This impacted usability and accessibility, especially for keyboard and pointer users.

**Proposed Changes :**

- Added a semi-transparent backdrop on hover for `.button--only-icon` elements with the ghost variant.
- The backdrop covers the full hit area and provides sufficient contrast with the icon.
- The change is limited to icon-only ghost buttons to preserve the ghost aesthetic for other button types.
- Ensured the solution aligns with WCAG guidelines for hover/focus visibility.

**Checklist :**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information :**

A subtle fade-in/out animation can be added in a future improvement for even smoother UI feedback. This enhancement improves user confidence and accessibility for icon-only ghost buttons.