### PR TITLE
Add Title component to ShelterUI

### DIFF
--- a/apps/storybook/.storybook/preview.ts
+++ b/apps/storybook/.storybook/preview.ts
@@ -15,7 +15,9 @@ const preview: Preview = {
       },
     },
     viewport: {
-      viewports: viewPorts,
+      options: {
+        ...viewPorts,
+      },
     },
     controls: {
       matchers: {

--- a/apps/storybook/stories/Components/Title.mdx
+++ b/apps/storybook/stories/Components/Title.mdx
@@ -1,0 +1,117 @@
+import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
+import * as TitleStories from './Title.stories';
+
+<Meta of={TitleStories} name="Title" />
+
+# ShelterUI Design System Title
+
+The `Title` component displays a section or page title with a customizable heading level, optional subtitle, icon, and different layouts.
+
+## Usage of the Title Component
+
+```tsx
+import { Title } from '@pplancq/shelter-ui-react';
+
+const MyComponent = () => {
+  return <Title title="Main title" subtitle="Subtitle" level={2} layout="stacked" />;
+};
+```
+
+## Title Props
+
+The `Title` component inherits all props from a `div` by default, or from the component passed via the `component` prop.
+
+<table id="title-props">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Type</th>
+      <th>Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>
+        <code>title</code>
+      </th>
+      <td>
+        <code>ReactNode</code>
+      </td>
+      <td>-</td>
+      <td>The main title (required).</td>
+    </tr>
+    <tr>
+      <th>
+        <code>subtitle</code>
+      </th>
+      <td>
+        <code>ReactNode</code>
+      </td>
+      <td>-</td>
+      <td>The subtitle displayed below the main title.</td>
+    </tr>
+    <tr>
+      <th>
+        <code>level</code>
+      </th>
+      <td>
+        <code>1 | 2 | 3 | 4 | 5 | 6</code>
+      </td>
+      <td>
+        <code>1</code>
+      </td>
+      <td>HTML heading level (h1 to h6) used for the title.</td>
+    </tr>
+    <tr>
+      <th>
+        <code>layout</code>
+      </th>
+      <td>
+        <code>'inline' | 'stacked'</code>
+      </td>
+      <td>
+        <code>'inline'</code>
+      </td>
+      <td>Layout of the title and subtitle: side by side or stacked.</td>
+    </tr>
+    <tr>
+      <th>
+        <code>icon</code>
+      </th>
+      <td>
+        <code>ReactNode</code>
+      </td>
+      <td>-</td>
+      <td>
+        Icon displayed to the left of the title.
+        <br />
+        <strong>Tip:</strong> Use the <code>Icon</code> component for best results.
+        <br />
+        <em>Example:</em> <code>{'<Icon icon={bookmarkIcon} />'}</code>
+      </td>
+    </tr>
+    <tr>
+      <th>
+        <code>component</code>
+      </th>
+      <td>
+        <code>ElementType</code>
+      </td>
+      <td>
+        <code>'div'</code>
+      </td>
+      <td>
+        Allows changing the root element (e.g., <code>section</code>).
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Demo
+
+Example usage of the `Title` component with different props.
+
+<Canvas of={TitleStories.Playground} sourceState="shown" />
+
+<Controls of={TitleStories.Playground} />

--- a/apps/storybook/stories/Components/Title.stories.tsx
+++ b/apps/storybook/stories/Components/Title.stories.tsx
@@ -1,0 +1,38 @@
+import bookmarkIcon from '@pplancq/shelter-ui-icon/icon/bookmark.svg';
+import { Icon, Title, type TitleProps } from '@pplancq/shelter-ui-react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta = {
+  title: 'Components/Title',
+  component: Title,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['!autodocs', '!dev'],
+  args: {
+    level: 1,
+    title: 'Title',
+    subtitle: 'Subtitle',
+    layout: 'inline',
+    icon: true,
+  },
+  argTypes: {
+    level: {
+      control: 'select',
+      options: [1, 2, 3, 4, 5, 6],
+    },
+    layout: {
+      control: 'select',
+      options: ['inline', 'stacked'],
+    },
+  },
+} satisfies Meta<TitleProps>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  tags: ['dev'],
+  render: ({ icon, ...args }) => <Title {...args} icon={icon ? <Icon icon={bookmarkIcon} /> : undefined} />,
+};

--- a/packages/css/sass/components/alert.scss
+++ b/packages/css/sass/components/alert.scss
@@ -6,8 +6,8 @@
 
 @use '../mixins/typography';
 
-@import '@fontsource/nunito/400.css'; /* regular - pour le message */
-@import '@fontsource/nunito/700.css'; /* bold - pour le titre */
+@import '@fontsource/nunito/400.css'; /* regular */
+@import '@fontsource/nunito/700.css'; /* bold */
 
 .alert {
   --alert-color: var(--color-signal-info-foreground);

--- a/packages/css/sass/components/title.scss
+++ b/packages/css/sass/components/title.scss
@@ -1,0 +1,94 @@
+@forward '../variables/typography';
+@forward '../variables/dimension';
+@forward '../variables/border';
+@forward '../themes/light';
+@forward '../themes/dark';
+
+@use '../mixins/typography';
+@use '../mixins/helpers';
+@use '../layout/responsive';
+
+@import '@fontsource/raleway/600.css'; /* semi-bold */
+@import '@fontsource/raleway/700.css'; /* bold */
+@import '@fontsource/nunito/700.css'; /* bold */
+
+@mixin title-group-heading($level, $subtitle-size) {
+  &:has(h#{$level}) {
+    .title__title {
+      @include typography.heading($level);
+    }
+
+    .title__subtitle {
+      @include typography.text($subtitle-size, true);
+    }
+  }
+}
+
+.title {
+  --title-color: var(--color-text-primary);
+  --title-subtitle-color: var(--color-text-secondary);
+  --title-border-color: var(--color-primary-main-medium);
+  --title-padding-v: var(--padding-0-5);
+  --title-padding-h: var(--padding-2);
+  --title-gap: var(--gap-1);
+  --title-icon-size: #{helpers.px-to-rem(24)};
+
+  all: unset;
+  display: flex;
+  min-width: 100%;
+  padding-inline: var(--title-padding-h);
+  padding-block: var(--title-padding-v);
+  border-bottom: 1px solid var(--title-border-color);
+  align-items: end;
+  gap: var(--title-gap);
+
+  @include responsive.media-exceeds-width(tablet) {
+    min-width: helpers.px-to-rem(500);
+  }
+
+  &__group {
+    all: unset;
+    display: flex;
+    align-items: end;
+    gap: var(--gap-2);
+
+    @include title-group-heading(1, large);
+    @include title-group-heading(2, medium);
+    @include title-group-heading(3, small);
+    @include title-group-heading(4, small);
+    @include title-group-heading(5, smaller);
+    @include title-group-heading(6, smallest);
+  }
+
+  & svg {
+    width: var(--title-icon-size);
+    height: var(--title-icon-size);
+    fill: var(--title-color);
+  }
+
+  &:has(h4, h5, h6) {
+    & svg {
+      --title-icon-size: #{helpers.px-to-rem(20)};
+    }
+  }
+
+  &__title {
+    all: unset;
+    color: var(--title-color);
+  }
+
+  &__subtitle {
+    all: unset;
+    color: var(--title-subtitle-color);
+  }
+
+  &--stacked {
+    align-items: start;
+
+    .title__group {
+      flex-direction: column;
+      align-items: start;
+      justify-content: center;
+    }
+  }
+}

--- a/packages/css/sass/shelter-ui.scss
+++ b/packages/css/sass/shelter-ui.scss
@@ -11,6 +11,7 @@
 @use 'components/helper-text';
 @use 'components/input-field';
 @use 'components/alert';
+@use 'components/title';
 
 @import '@fontsource/raleway/600.css'; /* semi-bold */
 @import '@fontsource/raleway/700.css'; /* bold */

--- a/packages/react/src/Title/Title.tsx
+++ b/packages/react/src/Title/Title.tsx
@@ -1,0 +1,45 @@
+import { clsx } from '@/utils/clsx';
+import type { ExtendableComponent } from '@/utils/types';
+import { type ElementType, JSX, type ReactNode, useId } from 'react';
+
+export type TitleProps<C extends ElementType = 'div'> = Omit<ExtendableComponent<C>, 'children'> & {
+  icon?: ReactNode;
+  level?: 1 | 2 | 3 | 4 | 5 | 6;
+  title: ReactNode;
+  subtitle?: ReactNode;
+  layout?: 'inline' | 'stacked';
+};
+
+export const Title = <C extends ElementType>({
+  component,
+  icon,
+  level = 1,
+  title,
+  subtitle,
+  layout = 'inline',
+  className,
+  id,
+  ...props
+}: TitleProps<C>) => {
+  const Component = (component || 'div') as keyof JSX.IntrinsicElements;
+  const HeadingTag = `h${level}` as keyof JSX.IntrinsicElements;
+  const headingId = useId();
+
+  const headingIdFinal = id ? `${id}-heading` : headingId;
+
+  return (
+    <Component className={clsx('title', layout === 'stacked' && 'title--stacked', className)} id={id} {...props}>
+      {icon}
+      <hgroup className="title__group">
+        <HeadingTag className="title__title" id={headingIdFinal}>
+          {title}
+        </HeadingTag>
+        {subtitle && (
+          <p className="title__subtitle" aria-describedby={headingIdFinal}>
+            {subtitle}
+          </p>
+        )}
+      </hgroup>
+    </Component>
+  );
+};

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -7,3 +7,4 @@ export { Label, type LabelProps } from './Label/Label';
 export { HelperText, type HelperTextProps } from './HelperText/HelperText';
 export { InputField, type InputFieldProps } from './InputField/InputField';
 export { Alert, type AlertProps } from './Alert/Alert';
+export { Title, type TitleProps } from './Title/Title';

--- a/packages/react/tests/Title/Title.test.tsx
+++ b/packages/react/tests/Title/Title.test.tsx
@@ -1,0 +1,134 @@
+import { Title } from '@/Title/Title';
+import { renderSuspense } from '@pplancq/svg-react/tests';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+describe('Title', () => {
+  it('should render with default props', async () => {
+    await renderSuspense(<Title title="Title text" data-testid="test-id" />);
+    const heading = screen.getByRole('heading', { level: 1, name: /title text/i });
+    const titleElement = screen.getByTestId('test-id');
+
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveClass('title__title');
+    expect(heading.tagName).toStrictEqual('H1');
+    expect(titleElement).toHaveClass('title');
+    expect(titleElement).not.toHaveClass('title--stacked');
+  });
+
+  it.each([
+    { level: 1 as const, description: 'level 1 heading' },
+    { level: 2 as const, description: 'level 2 heading' },
+    { level: 3 as const, description: 'level 3 heading' },
+    { level: 4 as const, description: 'level 4 heading' },
+    { level: 5 as const, description: 'level 5 heading' },
+    { level: 6 as const, description: 'level 6 heading' },
+  ])('should render with $description', async ({ level }) => {
+    await renderSuspense(<Title title={`Title ${level}`} level={level} />);
+    const heading = screen.getByRole('heading', { level, name: new RegExp(`title ${level}`, 'i') });
+
+    expect(heading.tagName).toStrictEqual(`H${level}`);
+  });
+
+  it.each([
+    { layout: 'inline' as const, expectedClass: 'title', description: 'inline layout (default)' },
+    { layout: 'stacked' as const, expectedClass: 'title title--stacked', description: 'stacked layout' },
+  ])('should render with $description', async ({ layout, expectedClass }) => {
+    await renderSuspense(<Title title="Layout test" layout={layout} data-testid="test-id" />);
+    const container = screen.getByTestId('test-id');
+
+    expect(container).toHaveClass('title');
+    expect(container).toHaveClass(expectedClass);
+  });
+
+  it('should render with subtitle', async () => {
+    await renderSuspense(<Title title="Main title" subtitle="Subtitle text" />);
+    const subtitle = screen.getByText(/subtitle text/i);
+    const heading = screen.getByRole('heading', { name: /main title/i });
+
+    expect(subtitle).toBeInTheDocument();
+    expect(subtitle).toHaveClass('title__subtitle');
+    expect(subtitle).toHaveAttribute('aria-describedby', heading.id);
+  });
+
+  it('should not render subtitle when not provided', async () => {
+    await renderSuspense(<Title title="Title only" />);
+    const subtitle = screen.queryByText(/subtitle/i);
+
+    expect(subtitle).not.toBeInTheDocument();
+  });
+
+  it('should render with icon', async () => {
+    const iconElement = <svg role="presentation" />;
+    await renderSuspense(<Title title="Title with icon" icon={iconElement} />);
+    const icon = screen.getByRole('presentation');
+
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('should render with custom component', async () => {
+    await renderSuspense(<Title title="Custom component" component="section" data-testid="test-id" />);
+    const container = screen.getByTestId('test-id');
+
+    expect(container).toBeInTheDocument();
+    expect(container).toHaveClass('title');
+    expect(container.tagName).toStrictEqual('SECTION');
+  });
+
+  it('should apply additional class names', async () => {
+    await renderSuspense(<Title title="Custom class" className="custom-class" data-testid="test-id" />);
+    const container = screen.getByTestId('test-id');
+
+    expect(container).toHaveClass('title');
+    expect(container).toHaveClass('custom-class');
+  });
+
+  it('should forward additional props to the container element', async () => {
+    await renderSuspense(<Title title="Props test" data-testid="custom-title" id="title-1" />);
+    const container = screen.getByTestId('custom-title');
+
+    expect(container).toHaveAttribute('id', 'title-1');
+  });
+
+  it('should generate unique heading ID when no id is provided', async () => {
+    await renderSuspense(<Title title="Auto ID test" />);
+    const heading = screen.getByRole('heading', { name: /auto id test/i });
+
+    expect(heading).toHaveAttribute('id');
+  });
+
+  it('should use custom heading ID when id is provided', async () => {
+    await renderSuspense(<Title title="Custom ID test" id="custom-title" />);
+    const heading = screen.getByRole('heading', { name: /custom id test/i });
+
+    expect(heading).toHaveAttribute('id', 'custom-title-heading');
+  });
+
+  it('should render complete title with all props', async () => {
+    const iconElement = <svg data-testid="complete-icon" />;
+    await renderSuspense(
+      <Title
+        title="Complete title"
+        subtitle="Complete subtitle"
+        level={2}
+        layout="stacked"
+        icon={iconElement}
+        className="complete-class"
+        id="complete-id"
+        data-testid="complete-id"
+      />,
+    );
+
+    const container = screen.getByTestId('complete-id');
+    const heading = screen.getByRole('heading', { level: 2, name: /complete title/i });
+    const subtitle = screen.getByText(/complete subtitle/i);
+    const icon = screen.getByTestId('complete-icon');
+
+    expect(container).toHaveClass('title', 'title--stacked', 'complete-class');
+    expect(heading).toHaveClass('title__title');
+    expect(heading).toHaveAttribute('id', 'complete-id-heading');
+    expect(subtitle).toHaveClass('title__subtitle');
+    expect(subtitle).toHaveAttribute('aria-describedby', 'complete-id-heading');
+    expect(icon).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
**Type of Pull Request :**

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue :**

Closes #235

**Context :**

This Pull Request introduces the new `Title` component to the ShelterUI design system. The `Title` component provides a flexible and accessible way to display section or page titles, with support for different heading levels, optional subtitles, icons, and layout variants. This addition aims to standardize title presentation across the application and improve UI consistency.

**Proposed Changes :**

- Added the `Title` React component with customizable props (`title`, `subtitle`, `level`, `icon`, `layout`, `component`).
- Created associated SCSS styles for the `Title` component, including responsive and theme support.
- Integrated the `Title` component into the main package exports.
- Added Storybook stories and MDX documentation for the `Title` component, including usage examples and props table.
- Implemented comprehensive unit tests for the `Title` component.
- Updated the main stylesheet to include the new `title` styles.

**Checklist :**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information :**

If you have any feedback or suggestions for the `Title` component API or its documentation, please let me know.