### PR TITLE
Add sass-true tests and Vitest integration for SCSS mixins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2996,6 +2996,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.6.1.tgz",
@@ -4707,6 +4720,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -6974,6 +6994,23 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/chromatic": {
       "version": "13.1.3",
       "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-13.1.3.tgz",
@@ -8189,6 +8226,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/dir-glob": {
@@ -11648,6 +11695,113 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-diff/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz",
@@ -13318,6 +13472,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -16620,6 +16775,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -16749,6 +16905,7 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -17041,6 +17198,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.2.tgz",
       "integrity": "sha512-eTonaQvPZ/3i1ASDHOKkYwAybiM45zFIc7KXils4mQmHLqIswXD9XNOKEVxtTFnsmwYzF66u4LMgSr0abDlh5w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -18011,6 +18169,21 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/recast": {
       "version": "0.23.11",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
@@ -18485,6 +18658,28 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/sass": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.90.0.tgz",
+      "integrity": "sha512-9GUyuksjw70uNpb1MTYWsH9MQHOHY6kwfnkafC24+7aOMZn9+rVMBxRbLvw756mrBFbIsFg6Xw9IkR2Fnn3k+Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chokidar": "^4.0.0",
+        "immutable": "^5.0.2",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
+      }
+    },
     "node_modules/sass-embedded": {
       "version": "1.90.0",
       "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.90.0.tgz",
@@ -18558,6 +18753,24 @@
       ],
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-true": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/sass-true/-/sass-true-7.0.1.tgz",
+      "integrity": "sha512-7qt24tkX45b3Cs/U5e6+OiHHoorCISzrDACQLtPV8cHDZc//++KMUFSJisXhoVfwuWEVJugzImQITI1GfzoTFQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@adobe/css-tools": "^4.3.2",
+        "jest-diff": "^29.7.0",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "sass": ">=1.45.0"
       }
     },
     "node_modules/saxes": {
@@ -19121,6 +19334,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -21837,19 +22051,24 @@
         "@fontsource/jetbrains-mono": "^5.2.6",
         "@fontsource/nunito": "^5.2.6",
         "@fontsource/oswald": "^5.2.6",
-        "@fontsource/raleway": "^5.2.6",
-        "postcss-discard-duplicates": "^7.0.2"
+        "@fontsource/raleway": "^5.2.6"
       },
       "devDependencies": {
+        "@pplancq/eslint-config": "^5.0.4",
         "@pplancq/postcss-config": "^2.1.14",
         "@pplancq/prettier-config": "^1.2.7",
         "@pplancq/stylelint-config": "^4.0.3",
         "@rsbuild/plugin-sass": "^1.3.5",
         "@rslib/core": "^0.12.1",
         "concurrently": "^9.2.0",
+        "eslint": "^9.33.0",
+        "eslint-plugin-prettier": "^5.5.4",
+        "postcss-discard-duplicates": "^7.0.2",
         "prettier": "^3.6.2",
+        "sass-true": "^7.0.0",
         "stylelint": "^16.23.1",
-        "stylelint-prettier": "^5.0.3"
+        "stylelint-prettier": "^5.0.3",
+        "vitest": "^3.2.4"
       },
       "engines": {
         "node": ">= 22"

--- a/packages/css/eslint.config.mjs
+++ b/packages/css/eslint.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from '@pplancq/eslint-config';
+
+export default defineConfig({
+  enableReact: false,
+  enableVitest: true,
+  enablePrettier: 'on',
+});

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -26,23 +26,39 @@
   "scripts": {
     "dev": "rslib build --watch",
     "build": "rslib build",
-    "lint": "concurrently --prefix-colors auto \"npm:stylelint\"",
-    "stylelint": "stylelint \"sass/**/*.{scss,css}\"",
-    "stylelint:fix": "stylelint \"sass/**/*.{scss,css}\" --fix"
+    "lint": "concurrently --prefix-colors auto \"npm:stylelint\" \"npm:eslint\"",
+    "eslint": "eslint \"tests/**/*.{js,jsx,ts,tsx}\"",
+    "eslint:fix": "eslint \"tests/**/*.{js,jsx,ts,tsx}\" --fix",
+    "stylelint": "stylelint \"{sass,tests}/**/*.{scss,css}\"",
+    "stylelint:fix": "stylelint \"{sass,tests}/**/*.{scss,css}\" --fix",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "engines": {
     "node": ">= 22"
   },
+  "dependencies": {
+    "@fontsource/jetbrains-mono": "^5.2.6",
+    "@fontsource/nunito": "^5.2.6",
+    "@fontsource/oswald": "^5.2.6",
+    "@fontsource/raleway": "^5.2.6"
+  },
   "devDependencies": {
+    "@pplancq/eslint-config": "^5.0.4",
     "@pplancq/postcss-config": "^2.1.14",
     "@pplancq/prettier-config": "^1.2.7",
     "@pplancq/stylelint-config": "^4.0.3",
     "@rsbuild/plugin-sass": "^1.3.5",
     "@rslib/core": "^0.12.1",
     "concurrently": "^9.2.0",
+    "eslint": "^9.33.0",
+    "eslint-plugin-prettier": "^5.5.4",
+    "postcss-discard-duplicates": "^7.0.2",
     "prettier": "^3.6.2",
+    "sass-true": "^7.0.0",
     "stylelint": "^16.23.1",
-    "stylelint-prettier": "^5.0.3"
+    "stylelint-prettier": "^5.0.3",
+    "vitest": "^3.2.4"
   },
   "prettier": "@pplancq/prettier-config",
   "lint-staged": {
@@ -51,12 +67,5 @@
   },
   "volta": {
     "extends": "../../package.json"
-  },
-  "dependencies": {
-    "@fontsource/jetbrains-mono": "^5.2.6",
-    "@fontsource/nunito": "^5.2.6",
-    "@fontsource/oswald": "^5.2.6",
-    "@fontsource/raleway": "^5.2.6",
-    "postcss-discard-duplicates": "^7.0.2"
   }
 }

--- a/packages/css/sass/layout/_responsive.scss
+++ b/packages/css/sass/layout/_responsive.scss
@@ -3,10 +3,10 @@
 
 $breakpoints: (
   mobile: 0,
-  tablet: helpers.px-to-rem(668),
-  desktop-small: helpers.px-to-rem(1024),
-  desktop-medium: helpers.px-to-rem(1280),
-  desktop-large: helpers.px-to-rem(1600),
+  tablet: 668,
+  desktop-small: 1024,
+  desktop-medium: 1280,
+  desktop-large: 1600,
 );
 
 @mixin media-exceeds-width($name) {
@@ -15,7 +15,7 @@ $breakpoints: (
   }
   $value: map.get($breakpoints, $name);
 
-  @media (width >= $value) {
+  @media (width >= #{helpers.px-to-rem($value)}) {
     @content;
   }
 }
@@ -26,7 +26,7 @@ $breakpoints: (
   }
   $value: map.get($breakpoints, $name);
 
-  @media (width < $value) {
+  @media (width < #{helpers.px-to-rem($value)}) {
     @content;
   }
 }
@@ -42,11 +42,11 @@ $breakpoints: (
   $startValue: map.get($breakpoints, $start);
   $endValue: map.get($breakpoints, $end);
 
-  @if $startValue > map.get($breakpoints, $endValue) {
+  @if $startValue > $endValue {
     @error "The start breakpoint (#{$startValue}) must be less than the end breakpoint (#{$endValue}).";
   }
 
-  @media (width >= $startValue) and (width < $endValue) {
+  @media (width >= #{helpers.px-to-rem($startValue)}) and (width < #{helpers.px-to-rem($endValue)}) {
     @content;
   }
 }

--- a/packages/css/sass/mixins/_helpers.scss
+++ b/packages/css/sass/mixins/_helpers.scss
@@ -9,9 +9,9 @@ $root-font-size: 16px;
     @error "The value #{$value} is not a valid number or dimension.";
   }
 
-  $number: if(meta.type-of($value) == 'dimension', $value / 1px, $value);
+  $number: if(math.unit($value) == 'px', math.div($value, 1px), $value);
 
-  @return #{'#{math.div($number, math.div($root-font-size, 1px))}rem'};
+  @return #{math.div($number, math.div($root-font-size, 1px))}rem;
 }
 
 @function split-list($list, $limit) {

--- a/packages/css/tests/layout/grid.spec.scss
+++ b/packages/css/tests/layout/grid.spec.scss
@@ -1,0 +1,75 @@
+@use 'true' as *;
+@use '../../sass/layout/grid';
+@use '../../sass/layout/responsive';
+
+@include describe('generate-responsive-grid') {
+  @include it('should generate CSS variables for tablet breakpoint') {
+    @include assert {
+      @include output {
+        .test-grid {
+          @include grid.generate-responsive-grid(
+            (
+              tablet: (
+                cols: 8,
+                margin-h: 2rem,
+                gap: 1rem,
+              ),
+            )
+          );
+        }
+      }
+      @include expect {
+        @media (width >= 41.75rem) {
+          .test-grid {
+            --cols: 8;
+            --margin-h: 2rem;
+            --gap: 1rem;
+          }
+        }
+      }
+    }
+  }
+}
+
+@include describe('generate-grid-item-classes') {
+  @include it('should generate grid-column for grid-item at all breakpoints') {
+    @include assert {
+      @include output {
+        .test-output {
+          @include grid.generate-grid-item-classes();
+        }
+      }
+      @include expect {
+        // stylelint-disable-next-line length-zero-no-unit
+        @media (width >= 0rem) {
+          .test-output [class*='grid-item'] {
+            grid-column: var(--start-mobile, var(--start)) / span var(--col-mobile, var(--col, var(--cols)));
+          }
+        }
+        @media (width >= 41.75rem) {
+          .test-output [class*='grid-item'] {
+            grid-column: var(--start-tablet, var(--start)) / span var(--col-tablet, var(--col, var(--cols)));
+          }
+        }
+        @media (width >= 64rem) {
+          .test-output [class*='grid-item'] {
+            grid-column: var(--start-desktop-small, var(--start)) / span
+              var(--col-desktop-small, var(--col, var(--cols)));
+          }
+        }
+        @media (width >= 80rem) {
+          .test-output [class*='grid-item'] {
+            grid-column: var(--start-desktop-medium, var(--start)) / span
+              var(--col-desktop-medium, var(--col, var(--cols)));
+          }
+        }
+        @media (width >= 100rem) {
+          .test-output [class*='grid-item'] {
+            grid-column: var(--start-desktop-large, var(--start)) / span
+              var(--col-desktop-large, var(--col, var(--cols)));
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/css/tests/layout/grid.test.ts
+++ b/packages/css/tests/layout/grid.test.ts
@@ -1,0 +1,11 @@
+import path from 'node:path';
+import sassTrue from 'sass-true';
+import { describe, it } from 'vitest';
+
+describe('Grid Mixins', () => {
+  const file = path.resolve(__dirname, 'grid.spec.scss');
+
+  sassTrue.runSass({ describe, it }, file, {
+    loadPaths: [path.resolve(__dirname, '../../sass')],
+  });
+});

--- a/packages/css/tests/layout/responsive.spec.scss
+++ b/packages/css/tests/layout/responsive.spec.scss
@@ -1,0 +1,65 @@
+@use 'true' as *;
+@use '../../sass/layout/responsive';
+
+@include describe('media-exceeds-width') {
+  @include it('should apply styles for width >= breakpoint') {
+    @include assert {
+      @include output {
+        @include responsive.media-exceeds-width(tablet) {
+          .test {
+            color: red;
+          }
+        }
+      }
+      @include expect {
+        @media (width >= 41.75rem) {
+          .test {
+            color: red;
+          }
+        }
+      }
+    }
+  }
+}
+
+@include describe('media-less-than-width') {
+  @include it('should apply styles for width < breakpoint') {
+    @include assert {
+      @include output {
+        @include responsive.media-less-than-width(desktop-small) {
+          .test {
+            color: blue;
+          }
+        }
+      }
+      @include expect {
+        @media (width < 64rem) {
+          .test {
+            color: blue;
+          }
+        }
+      }
+    }
+  }
+}
+
+@include describe('media-between-widths') {
+  @include it('should apply styles between two breakpoints') {
+    @include assert {
+      @include output {
+        @include responsive.media-between-widths(tablet, desktop-small) {
+          .test {
+            color: green;
+          }
+        }
+      }
+      @include expect {
+        @media (width >= 41.75rem) and (width < 64rem) {
+          .test {
+            color: green;
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/css/tests/layout/responsive.test.ts
+++ b/packages/css/tests/layout/responsive.test.ts
@@ -1,0 +1,11 @@
+import path from 'node:path';
+import sassTrue from 'sass-true';
+import { describe, it } from 'vitest';
+
+describe('Responsive Mixins', () => {
+  const file = path.resolve(__dirname, 'responsive.spec.scss');
+
+  sassTrue.runSass({ describe, it }, file, {
+    loadPaths: [path.resolve(__dirname, '../../sass')],
+  });
+});

--- a/packages/css/tests/mixins/helpers.spec.scss
+++ b/packages/css/tests/mixins/helpers.spec.scss
@@ -1,0 +1,53 @@
+@use 'true' as *;
+@use 'sass:meta';
+@use '../../sass/mixins/helpers';
+
+@include describe('px-to-rem') {
+  @include it('should convert px to rem') {
+    @include assert {
+      @include output {
+        .rem-16 {
+          font-size: helpers.px-to-rem(16px);
+        }
+      }
+      @include expect {
+        .rem-16 {
+          font-size: 1rem;
+        }
+      }
+    }
+  }
+  @include it('should convert number to rem') {
+    @include assert {
+      @include output {
+        .rem-32 {
+          font-size: helpers.px-to-rem(32);
+        }
+      }
+      @include expect {
+        .rem-32 {
+          font-size: 2rem;
+        }
+      }
+    }
+  }
+}
+
+@include describe('split-list') {
+  @include it('should split a list up to the limit') {
+    @include assert {
+      @include output {
+        $result: helpers.split-list((a, b, c, d), 2);
+
+        .split-list {
+          content: meta.inspect($result);
+        }
+      }
+      @include expect {
+        .split-list {
+          content: a b;
+        }
+      }
+    }
+  }
+}

--- a/packages/css/tests/mixins/helpers.test.ts
+++ b/packages/css/tests/mixins/helpers.test.ts
@@ -1,0 +1,11 @@
+import path from 'node:path';
+import sassTrue from 'sass-true';
+import { describe, it } from 'vitest';
+
+describe('Helpers Mixins', () => {
+  const file = path.resolve(__dirname, 'helpers.spec.scss');
+
+  sassTrue.runSass({ describe, it }, file, {
+    loadPaths: [path.resolve(__dirname, '../../sass')],
+  });
+});

--- a/packages/css/tests/mixins/outline-on-focus-visible.spec.scss
+++ b/packages/css/tests/mixins/outline-on-focus-visible.spec.scss
@@ -1,0 +1,63 @@
+/* stylelint-disable order/properties-order */
+@use 'true' as *;
+@use '../../sass/mixins/outline-on-focus-visible' as outline;
+
+@include describe('outline-on-focus-visible') {
+  @include it('should generate :focus-visible selector with outline styles') {
+    @include assert {
+      @include output {
+        .test-button {
+          @include outline.outline-on-focus-visible();
+        }
+      }
+      @include expect {
+        .test-button :focus-visible {
+          outline: 2px solid var(--color-primary-main-light);
+          outline-offset: 2px;
+        }
+      }
+    }
+  }
+
+  @include it('should inject @content inside :focus-visible selector') {
+    @include assert {
+      @include output {
+        .test-input {
+          @include outline.outline-on-focus-visible() {
+            border-color: var(--color-primary-main);
+            background-color: var(--color-background-light);
+          }
+        }
+      }
+      @include expect {
+        .test-input :focus-visible {
+          outline: 2px solid var(--color-primary-main-light);
+          outline-offset: 2px;
+          border-color: var(--color-primary-main);
+          background-color: var(--color-background-light);
+        }
+      }
+    }
+  }
+
+  @include it('should work with nested selectors') {
+    @include assert {
+      @include output {
+        .form-group {
+          input {
+            @include outline.outline-on-focus-visible() {
+              box-shadow: 0 0 0 3px rgb(0 123 255 / 25%);
+            }
+          }
+        }
+      }
+      @include expect {
+        .form-group input :focus-visible {
+          outline: 2px solid var(--color-primary-main-light);
+          outline-offset: 2px;
+          box-shadow: 0 0 0 3px rgb(0 123 255 / 25%);
+        }
+      }
+    }
+  }
+}

--- a/packages/css/tests/mixins/outline-on-focus-visible.test.ts
+++ b/packages/css/tests/mixins/outline-on-focus-visible.test.ts
@@ -1,0 +1,11 @@
+import path from 'node:path';
+import sassTrue from 'sass-true';
+import { describe, it } from 'vitest';
+
+describe('Outline on Focus Visible Mixin', () => {
+  const file = path.resolve(__dirname, 'outline-on-focus-visible.spec.scss');
+
+  sassTrue.runSass({ describe, it }, file, {
+    loadPaths: [path.resolve(__dirname, '../../sass')],
+  });
+});

--- a/packages/css/tests/mixins/spacing.spec.scss
+++ b/packages/css/tests/mixins/spacing.spec.scss
@@ -1,0 +1,134 @@
+@use 'true' as *;
+@use '../../sass/mixins/spacing';
+
+@include describe('functions') {
+  @include it('should return expected var token for get-margin-horizontal') {
+    @include assert {
+      @include output {
+        .fn-margin-h {
+          margin-inline: spacing.get-margin-horizontal(2);
+        }
+      }
+      @include expect {
+        .fn-margin-h {
+          margin-inline: var(--margin-2);
+        }
+      }
+    }
+  }
+
+  @include it('should return expected var token for get-margin-vertical') {
+    @include assert {
+      @include output {
+        .fn-margin-v {
+          margin-block: spacing.get-margin-vertical(3);
+        }
+      }
+      @include expect {
+        .fn-margin-v {
+          margin-block: var(--margin-3);
+        }
+      }
+    }
+  }
+
+  @include it('should return expected var token for get-padding-horizontal') {
+    @include assert {
+      @include output {
+        .fn-padding-h {
+          padding-inline: spacing.get-padding-horizontal(2);
+        }
+      }
+      @include expect {
+        .fn-padding-h {
+          padding-inline: var(--padding-2);
+        }
+      }
+    }
+  }
+
+  @include it('should return expected var token for get-gap') {
+    @include assert {
+      @include output {
+        .fn-gap {
+          gap: spacing.get-gap(1);
+        }
+      }
+      @include expect {
+        .fn-gap {
+          gap: var(--gap-1);
+        }
+      }
+    }
+  }
+}
+
+@include describe('mixins') {
+  @include it('should generate custom property and margin-inline for init-margin-horizontal') {
+    @include assert {
+      @include output {
+        .mixin-margin-h {
+          @include spacing.init-margin-horizontal('component-spacing', 2);
+        }
+      }
+      @include expect {
+        .mixin-margin-h {
+          --component-spacing: var(--margin-2);
+
+          margin-inline: var(--component-spacing);
+        }
+      }
+    }
+  }
+
+  @include it('should generate custom property and margin-block for init-margin-vertical') {
+    @include assert {
+      @include output {
+        .mixin-margin-v {
+          @include spacing.init-margin-vertical('component-margin-v', 4);
+        }
+      }
+      @include expect {
+        .mixin-margin-v {
+          --component-margin-v: var(--margin-4);
+
+          margin-block: var(--component-margin-v);
+        }
+      }
+    }
+  }
+
+  @include it('should generate custom property and padding-inline for init-padding-horizontal') {
+    @include assert {
+      @include output {
+        .mixin-padding-h {
+          @include spacing.init-padding-horizontal('component-padding', 3);
+        }
+      }
+      @include expect {
+        .mixin-padding-h {
+          --component-padding: var(--padding-3);
+
+          padding-inline: var(--component-padding);
+        }
+      }
+    }
+  }
+
+  @include it('should generate custom property and gap for init-gap') {
+    @include assert {
+      @include output {
+        .mixin-gap {
+          @include spacing.init-gap('component-gap', 1);
+        }
+      }
+      @include expect {
+        .mixin-gap {
+          --component-gap: var(--gap-1);
+
+          gap: var(--component-gap);
+        }
+      }
+    }
+  }
+}

--- a/packages/css/tests/mixins/spacing.test.ts
+++ b/packages/css/tests/mixins/spacing.test.ts
@@ -1,0 +1,11 @@
+import path from 'node:path';
+import sassTrue from 'sass-true';
+import { describe, it } from 'vitest';
+
+describe('Spacing Mixins', () => {
+  const file = path.resolve(__dirname, 'spacing.spec.scss');
+
+  sassTrue.runSass({ describe, it }, file, {
+    loadPaths: [path.resolve(__dirname, '../../sass')],
+  });
+});

--- a/packages/css/tests/mixins/typography.spec.scss
+++ b/packages/css/tests/mixins/typography.spec.scss
@@ -1,0 +1,628 @@
+@use 'true' as *;
+@use '../../sass/mixins/typography';
+
+@include describe('display mixins') {
+  @include it('should apply correct styles for display mixin, D1') {
+    @include assert {
+      @include output {
+        .display-large {
+          @include typography.display(1);
+        }
+      }
+      @include expect {
+        .display-large {
+          font-family: var(--font-family-display);
+          font-size: var(--font-size-48);
+          font-weight: var(--font-weight-bold);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-48);
+        }
+
+        @media (width >= 41.75rem) {
+          .display-large {
+            font-size: var(--font-size-80);
+            line-height: var(--line-height-80);
+          }
+        }
+      }
+    }
+  }
+
+  @include it('should apply correct styles for display mixin, D2') {
+    @include assert {
+      @include output {
+        .display-medium {
+          @include typography.display(2);
+        }
+      }
+      @include expect {
+        .display-medium {
+          font-family: var(--font-family-display);
+          font-size: var(--font-size-36);
+          font-weight: var(--font-weight-bold);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-40);
+        }
+
+        @media (width >= 41.75rem) {
+          .display-medium {
+            font-size: var(--font-size-60);
+            line-height: var(--line-height-60);
+          }
+        }
+      }
+    }
+  }
+
+  @include it('should apply correct styles for display mixin, D3') {
+    @include assert {
+      @include output {
+        .display-small {
+          @include typography.display(3);
+        }
+      }
+      @include expect {
+        .display-small {
+          font-family: var(--font-family-display);
+          font-size: var(--font-size-24);
+          font-weight: var(--font-weight-bold);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-32);
+        }
+
+        @media (width >= 41.75rem) {
+          .display-small {
+            font-size: var(--font-size-48);
+            line-height: var(--line-height-48);
+          }
+        }
+      }
+    }
+  }
+
+  @include it('should apply correct styles for display mixin, D4') {
+    @include assert {
+      @include output {
+        .display-smaller {
+          @include typography.display(4);
+        }
+      }
+      @include expect {
+        .display-smaller {
+          font-family: var(--font-family-display);
+          font-size: var(--font-size-20);
+          font-weight: var(--font-weight-semi-bold);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-28);
+        }
+
+        @media (width >= 41.75rem) {
+          .display-smaller {
+            font-size: var(--font-size-36);
+            line-height: var(--line-height-40);
+          }
+        }
+      }
+    }
+  }
+
+  @include it('should apply correct styles for display mixin, D5') {
+    @include assert {
+      @include output {
+        .display-smallest {
+          @include typography.display(5);
+        }
+      }
+      @include expect {
+        .display-smallest {
+          font-family: var(--font-family-display);
+          font-size: var(--font-size-18);
+          font-weight: var(--font-weight-semi-bold);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-28);
+        }
+
+        @media (width >= 41.75rem) {
+          .display-smallest {
+            font-size: var(--font-size-24);
+            line-height: var(--line-height-32);
+          }
+        }
+      }
+    }
+  }
+
+  @include it('should apply correct styles for display mixin, D6') {
+    @include assert {
+      @include output {
+        .display-tiny {
+          @include typography.display(6);
+        }
+      }
+      @include expect {
+        .display-tiny {
+          font-family: var(--font-family-display);
+          font-size: var(--font-size-16);
+          font-weight: var(--font-weight-semi-bold);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-24);
+        }
+
+        @media (width >= 41.75rem) {
+          .display-tiny {
+            font-size: var(--font-size-20);
+            line-height: var(--line-height-28);
+          }
+        }
+      }
+    }
+  }
+}
+
+@include describe('heading mixins') {
+  @include it('should apply correct styles for heading mixin, H1') {
+    @include assert {
+      @include output {
+        .heading-large {
+          @include typography.heading(1);
+        }
+      }
+      @include expect {
+        .heading-large {
+          font-family: var(--font-family-heading);
+          font-size: var(--font-size-24);
+          font-weight: var(--font-weight-bold);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-32);
+        }
+
+        @media (width >= 41.75rem) {
+          .heading-large {
+            font-size: var(--font-size-30);
+            line-height: var(--line-height-36);
+          }
+        }
+      }
+    }
+  }
+
+  @include it('should apply correct styles for heading mixin, H2') {
+    @include assert {
+      @include output {
+        .heading-medium {
+          @include typography.heading(2);
+        }
+      }
+      @include expect {
+        .heading-medium {
+          font-family: var(--font-family-heading);
+          font-size: var(--font-size-20);
+          font-weight: var(--font-weight-bold);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-28);
+        }
+
+        @media (width >= 41.75rem) {
+          .heading-medium {
+            font-size: var(--font-size-24);
+            line-height: var(--line-height-32);
+          }
+        }
+      }
+    }
+  }
+
+  @include it('should apply correct styles for heading mixin, H3') {
+    @include assert {
+      @include output {
+        .heading-small {
+          @include typography.heading(3);
+        }
+      }
+      @include expect {
+        .heading-small {
+          font-family: var(--font-family-heading);
+          font-size: var(--font-size-18);
+          font-weight: var(--font-weight-bold);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-28);
+        }
+
+        @media (width >= 41.75rem) {
+          .heading-small {
+            font-size: var(--font-size-20);
+            line-height: var(--line-height-28);
+          }
+        }
+      }
+    }
+  }
+
+  @include it('should apply correct styles for heading mixin, H4') {
+    @include assert {
+      @include output {
+        .heading-smaller {
+          @include typography.heading(4);
+        }
+      }
+      @include expect {
+        .heading-smaller {
+          font-family: var(--font-family-heading);
+          font-size: var(--font-size-16);
+          font-weight: var(--font-weight-semi-bold);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-24);
+        }
+
+        @media (width >= 41.75rem) {
+          .heading-smaller {
+            font-size: var(--font-size-18);
+            line-height: var(--line-height-28);
+          }
+        }
+      }
+    }
+  }
+
+  @include it('should apply correct styles for heading mixin, H5') {
+    @include assert {
+      @include output {
+        .heading-smallest {
+          @include typography.heading(5);
+        }
+      }
+      @include expect {
+        .heading-smallest {
+          font-family: var(--font-family-heading);
+          font-size: var(--font-size-14);
+          font-weight: var(--font-weight-semi-bold);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-20);
+        }
+
+        @media (width >= 41.75rem) {
+          .heading-smallest {
+            font-size: var(--font-size-16);
+            line-height: var(--line-height-24);
+          }
+        }
+      }
+    }
+  }
+
+  @include it('should apply correct styles for heading mixin, H6') {
+    @include assert {
+      @include output {
+        .heading-tiny {
+          @include typography.heading(6);
+        }
+      }
+      @include expect {
+        .heading-tiny {
+          font-family: var(--font-family-heading);
+          font-size: var(--font-size-12);
+          font-weight: var(--font-weight-semi-bold);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-16);
+        }
+
+        @media (width >= 41.75rem) {
+          .heading-tiny {
+            font-size: var(--font-size-14);
+            line-height: var(--line-height-20);
+          }
+        }
+      }
+    }
+  }
+}
+
+@include describe('text mixins') {
+  @include it('should apply correct styles for text mixin, large regular') {
+    @include assert {
+      @include output {
+        .text-regular {
+          @include typography.text(large);
+        }
+      }
+      @include expect {
+        .text-regular {
+          font-family: var(--font-family-content);
+          font-size: var(--font-size-18);
+          font-weight: var(--font-weight-regular);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-28);
+        }
+      }
+    }
+  }
+
+  @include it('should apply correct styles for text mixin, large bold') {
+    @include assert {
+      @include output {
+        .text-bold {
+          @include typography.text(large, true);
+        }
+      }
+      @include expect {
+        .text-bold {
+          font-family: var(--font-family-content);
+          font-size: var(--font-size-18);
+          font-weight: var(--font-weight-bold);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-28);
+        }
+      }
+    }
+  }
+
+  @include it('should apply correct styles for text mixin, medium regular') {
+    @include assert {
+      @include output {
+        .text-regular {
+          @include typography.text(medium);
+        }
+      }
+      @include expect {
+        .text-regular {
+          font-family: var(--font-family-content);
+          font-size: var(--font-size-16);
+          font-weight: var(--font-weight-regular);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-24);
+        }
+      }
+    }
+  }
+
+  @include it('should apply correct styles for text mixin, medium bold') {
+    @include assert {
+      @include output {
+        .text-bold {
+          @include typography.text(medium, true);
+        }
+      }
+      @include expect {
+        .text-bold {
+          font-family: var(--font-family-content);
+          font-size: var(--font-size-16);
+          font-weight: var(--font-weight-bold);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-24);
+        }
+      }
+    }
+  }
+
+  @include it('should apply correct styles for text mixin, small regular') {
+    @include assert {
+      @include output {
+        .text-regular {
+          @include typography.text(small);
+        }
+      }
+      @include expect {
+        .text-regular {
+          font-family: var(--font-family-content);
+          font-size: var(--font-size-14);
+          font-weight: var(--font-weight-regular);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-20);
+        }
+      }
+    }
+  }
+
+  @include it('should apply correct styles for text mixin, small bold') {
+    @include assert {
+      @include output {
+        .text-bold {
+          @include typography.text(small, true);
+        }
+      }
+      @include expect {
+        .text-bold {
+          font-family: var(--font-family-content);
+          font-size: var(--font-size-14);
+          font-weight: var(--font-weight-bold);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-20);
+        }
+      }
+    }
+  }
+
+  @include it('should apply correct styles for text mixin, smaller regular') {
+    @include assert {
+      @include output {
+        .text-regular {
+          @include typography.text(smaller);
+        }
+      }
+      @include expect {
+        .text-regular {
+          font-family: var(--font-family-content);
+          font-size: var(--font-size-12);
+          font-weight: var(--font-weight-regular);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-16);
+        }
+      }
+    }
+  }
+
+  @include it('should apply correct styles for text mixin, smaller bold') {
+    @include assert {
+      @include output {
+        .text-bold {
+          @include typography.text(smaller, true);
+        }
+      }
+      @include expect {
+        .text-bold {
+          font-family: var(--font-family-content);
+          font-size: var(--font-size-12);
+          font-weight: var(--font-weight-bold);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-16);
+        }
+      }
+    }
+  }
+
+  @include it('should apply correct styles for text mixin, smallest regular') {
+    @include assert {
+      @include output {
+        .text-regular {
+          @include typography.text(smallest);
+        }
+      }
+      @include expect {
+        .text-regular {
+          font-family: var(--font-family-content);
+          font-size: var(--font-size-10);
+          font-weight: var(--font-weight-regular);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-13);
+        }
+      }
+    }
+  }
+
+  @include it('should apply correct styles for text mixin, smallest bold') {
+    @include assert {
+      @include output {
+        .text-bold {
+          @include typography.text(smallest, true);
+        }
+      }
+      @include expect {
+        .text-bold {
+          font-family: var(--font-family-content);
+          font-size: var(--font-size-10);
+          font-weight: var(--font-weight-bold);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-13);
+        }
+      }
+    }
+  }
+}
+
+@include describe('label mixins') {
+  @include it('should apply correct styles for label mixin') {
+    @include assert {
+      @include output {
+        .label {
+          @include typography.label(large);
+        }
+      }
+      @include expect {
+        .label {
+          font-family: var(--font-family-label);
+          font-size: var(--font-size-18);
+          font-weight: var(--font-weight-semi-bold);
+          letter-spacing: var(--letter-spacing-low);
+          line-height: var(--line-height-28);
+        }
+      }
+    }
+  }
+
+  @include it('should apply correct styles for label mixin, medium') {
+    @include assert {
+      @include output {
+        .label {
+          @include typography.label(medium);
+        }
+      }
+      @include expect {
+        .label {
+          font-family: var(--font-family-label);
+          font-size: var(--font-size-16);
+          font-weight: var(--font-weight-semi-bold);
+          letter-spacing: var(--letter-spacing-low);
+          line-height: var(--line-height-24);
+        }
+      }
+    }
+  }
+
+  @include it('should apply correct styles for label mixin, small') {
+    @include assert {
+      @include output {
+        .label {
+          @include typography.label(small);
+        }
+      }
+      @include expect {
+        .label {
+          font-family: var(--font-family-label);
+          font-size: var(--font-size-14);
+          font-weight: var(--font-weight-semi-bold);
+          letter-spacing: var(--letter-spacing-low);
+          line-height: var(--line-height-20);
+        }
+      }
+    }
+  }
+}
+
+@include describe('code mixins') {
+  @include it('should apply correct styles for code mixin') {
+    @include assert {
+      @include output {
+        .code {
+          @include typography.code(large);
+        }
+      }
+      @include expect {
+        .code {
+          font-family: var(--font-family-code);
+          font-size: var(--font-size-18);
+          font-weight: var(--font-weight-medium);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-28);
+        }
+      }
+    }
+  }
+
+  @include it('should apply correct styles for code mixin, medium') {
+    @include assert {
+      @include output {
+        .code {
+          @include typography.code(medium);
+        }
+      }
+      @include expect {
+        .code {
+          font-family: var(--font-family-code);
+          font-size: var(--font-size-16);
+          font-weight: var(--font-weight-medium);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-24);
+        }
+      }
+    }
+  }
+
+  @include it('should apply correct styles for code mixin, small') {
+    @include assert {
+      @include output {
+        .code {
+          @include typography.code(small);
+        }
+      }
+      @include expect {
+        .code {
+          font-family: var(--font-family-code);
+          font-size: var(--font-size-14);
+          font-weight: var(--font-weight-medium);
+          letter-spacing: var(--letter-spacing-default);
+          line-height: var(--line-height-20);
+        }
+      }
+    }
+  }
+}

--- a/packages/css/tests/mixins/typography.test.ts
+++ b/packages/css/tests/mixins/typography.test.ts
@@ -1,0 +1,11 @@
+import path from 'node:path';
+import sassTrue from 'sass-true';
+import { describe, it } from 'vitest';
+
+describe('Typography Mixins', () => {
+  const file = path.resolve(__dirname, 'typography.spec.scss');
+
+  sassTrue.runSass({ describe, it }, file, {
+    loadPaths: [path.resolve(__dirname, '../../sass')],
+  });
+});

--- a/packages/css/tests/variables/dimension.spec.scss
+++ b/packages/css/tests/variables/dimension.spec.scss
@@ -1,0 +1,93 @@
+@use 'true' as *;
+@use '../../sass/variables/dimension';
+
+@include describe('generate-dimension-variables mixin') {
+  @include it('should generate margin variables for primitives and additional values') {
+    @include assert {
+      @include output {
+        :root {
+          @include dimension.generate-dimension-variables(
+            'margin',
+            dimension.$margins,
+            dimension.$primitive-additional-value
+          );
+        }
+      }
+      @include expect {
+        :root {
+          --margin-0-5: 0.25rem;
+          --margin-2-5: 1.25rem;
+          --margin-3-5: 1.75rem;
+          --margin-0: 0rem;
+          --margin-1: 0.5rem;
+          --margin-2: 1rem;
+          --margin-3: 1.5rem;
+          --margin-4: 2rem;
+          --margin-5: 2.5rem;
+          --margin-6: 3rem;
+          --margin-7: 3.5rem;
+          --margin-8: 4rem;
+          --margin-9: 4.5rem;
+          --margin-10: 5rem;
+          --margin-11: 5.5rem;
+          --margin-12: 6rem;
+          --margin-13: 6.5rem;
+          --margin-14: 7rem;
+          --margin-15: 7.5rem;
+        }
+      }
+    }
+  }
+
+  @include it('should generate padding variables for primitives and additional values') {
+    @include assert {
+      @include output {
+        :root {
+          @include dimension.generate-dimension-variables(
+            'padding',
+            dimension.$paddings,
+            dimension.$primitive-additional-value
+          );
+        }
+      }
+      @include expect {
+        :root {
+          --padding-0-5: 0.25rem;
+          --padding-2-5: 1.25rem;
+          --padding-3-5: 1.75rem;
+          --padding-0: 0rem;
+          --padding-1: 0.5rem;
+          --padding-2: 1rem;
+          --padding-3: 1.5rem;
+          --padding-4: 2rem;
+        }
+      }
+    }
+  }
+
+  @include it('should generate gap variables for primitives and additional values') {
+    @include assert {
+      @include output {
+        :root {
+          @include dimension.generate-dimension-variables(
+            'gap',
+            dimension.$gaps,
+            dimension.$primitive-additional-value
+          );
+        }
+      }
+      @include expect {
+        :root {
+          --gap-0-5: 0.25rem;
+          --gap-2-5: 1.25rem;
+          --gap-3-5: 1.75rem;
+          --gap-0: 0rem;
+          --gap-1: 0.5rem;
+          --gap-2: 1rem;
+          --gap-3: 1.5rem;
+          --gap-4: 2rem;
+        }
+      }
+    }
+  }
+}

--- a/packages/css/tests/variables/dimension.test.ts
+++ b/packages/css/tests/variables/dimension.test.ts
@@ -1,0 +1,11 @@
+import path from 'node:path';
+import sassTrue from 'sass-true';
+import { describe, it } from 'vitest';
+
+describe('Dimension Mixins', () => {
+  const file = path.resolve(__dirname, 'dimension.spec.scss');
+
+  sassTrue.runSass({ describe, it }, file, {
+    loadPaths: [path.resolve(__dirname, '../../sass')],
+  });
+});

--- a/packages/css/tsconfig.json
+++ b/packages/css/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "lib": ["DOM", "ES2021"],
+    "module": "ESNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "bundler",
+    "useDefineForClassFields": true,
+    "types": ["vitest/globals"],
+    "baseUrl": "."
+  },
+  "include": ["tests"]
+}

--- a/packages/css/vitest.config.mts
+++ b/packages/css/vitest.config.mts
@@ -1,17 +1,13 @@
-import react from '@vitejs/plugin-react-swc';
 import { loadEnv } from 'vite';
-import viteTsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
 
   return {
-    plugins: [react(), viteTsconfigPaths()],
     test: {
-      name: 'React Tests',
-      environment: 'jsdom',
-      setupFiles: 'vitest.setup.ts',
+      name: 'CSS Tests',
+      environment: 'node',
       clearMocks: true,
       css: false,
       include: ['tests/**/*.{test,spec}.[jt]s?(x)'],
@@ -25,17 +21,6 @@ export default defineConfig(({ mode }) => {
           minForks: env.CI ? 1 : undefined,
           maxForks: env.CI ? 2 : undefined,
         },
-      },
-      coverage: {
-        enabled: env.CI === 'true',
-        reporter: ['lcov', 'json', 'html', 'text', 'cobertura'],
-        provider: 'v8',
-        lines: 80,
-        functions: 75,
-        branches: 80,
-        statements: 80,
-        include: ['src/**/*.[jt]s?(x)'],
-        exclude: ['src/**/*.d.[jt]s?(x)', 'src/**/*.types.[jt]s?(x)', 'src/**/index.[jt]s?(x)'],
       },
     },
   };

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -6,7 +6,7 @@ export default defineConfig(({ mode }) => {
 
   return {
     test: {
-      projects: ['./packages/react/vitest.config.mts'],
+      projects: ['./packages/react/vitest.config.mts', './packages/css/vitest.config.mts'],
       reporters: ['default', 'junit', 'vitest-sonar-reporter'],
       outputFile: {
         'vitest-sonar-reporter': 'sonar-report.xml',


### PR DESCRIPTION
**Type of Pull Request:**

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Other (specify):

**Associated Issue:**

Closes #55

**Context:**

This PR implements automated testing for SCSS mixins using sass-true and integrates those tests into the repository's testing tooling (Vitest). The change responds to the request in Issue #55 to validate that mixins generate the expected CSS output, to prevent regressions when refactoring SCSS utilities, and to provide examples for future tests. The changes add example tests for existing mixins (helpers, responsive, grid), wire up a Vitest-compatible runner for sass-true, and update the `packages/css` package to include necessary scripts and devDependencies.

**Proposed Changes:**

- Add sass-true spec files that assert generated CSS for mixins:
  - `packages/css/tests/mixins/helpers.spec.scss` — tests `helpers.px-to-rem` and `helpers.split-list`
  - `packages/css/tests/layout/responsive.spec.scss` — tests `media-exceeds-width`, `media-less-than-width`, `media-between-widths`
  - `packages/css/tests/layout/grid.spec.scss` — tests grid-related mixins and generated CSS variables
- Add Vitest integration files to run sass-true in node:
  - `packages/css/tests/mixins/helpers.test.ts`
  - `packages/css/tests/layout/responsive.test.ts`
  - `packages/css/tests/layout/grid.test.ts`
  These files use `sass-true` with Vitest's `describe`/`it` to execute `.spec.scss` assertions.
- Update `packages/css/package.json`:
  - Add `test` and `test:watch` scripts (`vitest run`, `vitest`) and expand `lint` scripts to run both `stylelint` and `eslint`.
  - Add necessary `dependencies` and `devDependencies` for the tests and tooling (`sass-true`, `vitest`, `eslint`, `eslint-plugin-prettier`, `@pplancq/eslint-config`, `sass-true`, etc.) to support running and linting tests.
- Add ESLint configuration for the package:
  - `packages/css/eslint.config.mjs` — enables `enableVitest` and Prettier integration for the package test code (disables React since CSS package is non-react).
- Fix and modernize SCSS implementation to be testable and compatible:
  - `packages/css/sass/mixins/_helpers.scss` — update `px-to-rem` implementation to use `sass:math` unit-aware operations (`math.div`) and correct return format to produce rem values reliably.
  - `packages/css/sass/layout/_responsive.scss` — change breakpoint values from helper-wrapped numbers to plain numeric breakpoints and ensure media queries call `helpers.px-to-rem()` where appropriate; fix comparisons and `$start/$end` logic for `media-between-widths`.
- Add unit-like expectations for generated CSS in `.spec.scss` files (examples of expected @media output and CSS custom properties).
- Update lockfile / dependency snapshot:
  - `package-lock.json` changed to reflect added/updated packages required by the new tooling (new entries for `sass`, `sass-true`, `vitest` and related transitive packages). This is the package manager's record of the new/updated devDependencies.

**Checklist:**

- [x] I have verified that my changes work as expected
- [x] I have updated the documentation if necessary
- [x] I have thought to rebase my branch
- [x] I have applied the correct label according to the type of PR (bug/feature/documentation)

**Additional Information:**

- How to run the new tests locally (from repository root):
  - cd into the package and run Vitest:
    - `cd packages/css`
    - `npm install` (if dependencies not installed)
    - `npm test` (runs `vitest run`) or `npm run test:watch`