### PR TITLE
fix(react,storybook): rollback TypeScript from v7 to v6

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -50,7 +50,7 @@
     "storybook-react-rsbuild": "^3.3.4",
     "stylelint": "^17.14.0",
     "stylelint-prettier": "^5.0.3",
-    "typescript": "^7.0.2"
+    "typescript": "^6.0.3"
   },
   "prettier": "@pplancq/prettier-config",
   "lint-staged": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "storybook-react-rsbuild": "^3.3.4",
         "stylelint": "^17.14.0",
         "stylelint-prettier": "^5.0.3",
-        "typescript": "^7.0.2"
+        "typescript": "^6.0.3"
       }
     },
     "apps/storybook/node_modules/typescript": {
@@ -25184,7 +25184,7 @@
         "prettier": "^3.9.5",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
-        "typescript": "^7.0.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.10",
         "vitest-sonar-reporter": "^3.0.0"
       },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -67,7 +67,7 @@
     "prettier": "^3.9.5",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.10",
     "vitest-sonar-reporter": "^3.0.0"
   },


### PR DESCRIPTION
## Description

Briefly describe what changed and why.

- Problem / feature: The repository was using TypeScript 7 while the `@typescript-eslint/*` ecosystem still targets TypeScript 6, causing compatibility issues during linting.
- Expected behavior: ESLint and `@typescript-eslint/*` work correctly with the version of TypeScript declared in the project.

Closes: #983

## Type of change

Please check the relevant option:

- [x] fix (bug fix)
- [ ] feat (new feature)
- [ ] docs (documentation only)
- [ ] style (formatting, lint, etc.)
- [ ] refactor (code change without new feature or bug fix)
- [ ] perf (performance improvement)
- [ ] test (adding or updating tests)
- [ ] ci (CI/configuration changes)
- [ ] chore (other tasks)

## How to test locally

- Install / prepare hooks:
  - npm install
  - npm run prepare

- Lint / typecheck:
  - npm run lint

- Tests:
  - Run full suite: `npm run test`

- Build:
  - Build all workspaces: `npm run build`

## Checklist (required before review)

- [x] Commits follow Conventional Commits with a valid scope.
- [x] Branch is named correctly (`feature/` or `bugfix/`).
- [x] Relevant tests added/updated and passing (`npm run test`).
- [x] Lint and formatting are OK (`npm run lint`).
- [x] Affected packages build successfully (`npm run build` / workspace build).
- [ ] Storybook updated/tested if UI changed (attach screenshot or Storybook link).
- [ ] Documentation (README, Storybook) updated if needed.
- [x] No unnecessary dependency changes in package.json.
- [x] Avoid using reserved scopes (`deps`, `release`) unless you are a maintainer.

## Notes for the reviewer

This change rolls back TypeScript from `^7.0.2` to `^6.0.3` in both the React package and the Storybook app. We should wait for upstream `@typescript-eslint/*` support for TypeScript 7 before upgrading again (tracked at [typescript-eslint/typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940)).

## Suggested labels

- bug
